### PR TITLE
[twitch-chat] now함수 수정(linux와 windows/mac 달라생기는문제)

### DIFF
--- a/chat/model/TwitchChatCollector.js
+++ b/chat/model/TwitchChatCollector.js
@@ -2,9 +2,11 @@ const tmi = require('tmi.js');
 const schedule = require('node-schedule');
 const doQuery = require('../lib/doQuery');
 const createChatInsertQueryValues = require('../lib/createChatInsertQueryValues');
+
 // utils
 const now = require('../utils/now');
 const arrayDivide = require('../utils/arrayDivide');
+
 // configure constants
 const BOT_NAME = 'OnADy';
 const BOT_OAUTH_TOKEN = 'oauth:ql78nrmxylz561jfwizzu7vi973vld';
@@ -264,7 +266,7 @@ function TwitchChatCollector() {
       console.log('[TIME]: ', new Date().toLocaleString());
       console.log('[Running clients]: ', this.status.running.length);
       console.log('[Number of collecting channels]: ', this.status.allRunningChannels.length);
-      console.log('[Collecting channels]: ', this.status.allRunningChannels.join(', '));
+      console.log('[Collecting channels]: ', this.status.allRunningChannels.slice(0, 10).join(', '));
       console.log('[Stopped clients]: ', this.status.stopped.length);
       console.log('[Number of stopped channels]: ', this.status.allStoppedChannels.length);
       console.log('[Stopped channels]: ', this.status.allStoppedChannels.join(', '));

--- a/chat/utils/now.js
+++ b/chat/utils/now.js
@@ -1,7 +1,14 @@
 // Date Fuction called when the message comes in
 function now() {
   const thisTime = new Date();
-  return thisTime.toLocaleString();
+  const year = thisTime.getFullYear();
+  const month = thisTime.getMonth();
+  const date = thisTime.getDate();
+  const hours = thisTime.getHours();
+  const minutes = thisTime.getMinutes();
+  const seconds = thisTime.getSeconds();
+
+  return `${year}-${month}-${date} ${hours}:${minutes}:${seconds}`;
 }
 
 module.exports = now;


### PR DESCRIPTION

- javascript Date 생성자의 toLocaleString() 사용시, 차이
- 해당 차이로 인해 시간이 0000-00-00 00:00:00 으로 표기되어 저장됨.
- linux/mac/windows 동일한 값을 반환하도록 함수 수정하였음.

Linux : 
```
> new Date()
2019-11-26T03:48:12.147Z
> new Date().toLocaleString()
'11/26/2019, 12:48:17 PM'
```

mac :
```
> new Date()
2019-11-26T03:48:12.147Z
> new Date().toLocaleString()
'2019-11-26 12:48:17'
```