### PR TITLE
[Update 3.1] 캐러셀 오류 세미최종수정 및 정책 페이지 폭 수정

### DIFF
--- a/client/src/organisms/main/Main/views/Carousel/MainCarousel.jsx
+++ b/client/src/organisms/main/Main/views/Carousel/MainCarousel.jsx
@@ -11,9 +11,6 @@ const useStyles = makeStyles(theme => ({
       display: 'none'
     },
   },
-  video: {
-    
-  }
 }));
 
 const autoReducer = (state, action) => {
@@ -80,22 +77,20 @@ const MainCarousel = () => {
   const [currVideo, setCurrVideo] = useState(800);
 
 // 3D carousel 구현
-
   let n = 10,
       theta = 2 * Math.PI / 10
   
   function carousel() {
-
-    let 
+      let 
       figure = tagfigure.current,
       videos = figure.children,
       gap = tagcarousel.current.dataset.gap || 0
 
     setupCarousel(n, parseFloat(getComputedStyle(videos[0]).width));
     
-    // window.addEventListener('resize', () => { 
-    //   setupCarousel(n, parseFloat(getComputedStyle(videos[0]).width)) 
-    // });
+    window.addEventListener('resize', () => { 
+      setupCarousel(n, parseFloat(getComputedStyle(videos[0]).width)) 
+    });
 
     function setupCarousel(n, s) {
       let	
@@ -114,7 +109,7 @@ const MainCarousel = () => {
       for (let i = 0; i < n; i++)
       videos[i].style.backfaceVisibility = 'hidden';
 
-      rotateCarousel(currVideo);
+      figure.style.transform = `rotateY(${currVideo * - theta}rad)`;
     }
   }
 
@@ -211,7 +206,6 @@ const MainCarousel = () => {
 
     const readyCreatorData = async () => {
       try {
-
         const res = await axios.get(`${HOST}/api/streams`,{
           cancelToken: source.token
         });
@@ -221,16 +215,15 @@ const MainCarousel = () => {
             setCreator(res.data);
             setLoading(true);
             carousel();       
-            setTimeout(function() {
             setTitle(true);
-          }, 2000)
+          
         }} else {
           alert('OnAD 홈페이지 방문을 환영합니다!')
         }
 
       } catch (error) {
         if (axios.isCancel(error)) {
-          console.log('axios=>canceled')
+          // 언마운트 이후에 실행할 함수들 넣어도 됨
         } else {
           throw error;
         }
@@ -242,7 +235,6 @@ const MainCarousel = () => {
     return () => {
       source.cancel();
       abortController.abort();
-      console.log('useEffect => canceled')
     };
 
   }, []);
@@ -262,7 +254,7 @@ const MainCarousel = () => {
                 </div>
               </nav>
               
-              <figure ref={tagfigure} className={classes.video}>
+              <figure ref={tagfigure}>
                   <iframe
                     title="hero"
                     src={`https://player.twitch.tv/?channel=${creator[0]}&autoplay=${auto0}`}

--- a/client/src/organisms/main/Main/views/Carousel/MainCarousel.jsx
+++ b/client/src/organisms/main/Main/views/Carousel/MainCarousel.jsx
@@ -11,6 +11,9 @@ const useStyles = makeStyles(theme => ({
       display: 'none'
     },
   },
+  video: {
+    
+  }
 }));
 
 const autoReducer = (state, action) => {
@@ -259,7 +262,7 @@ const MainCarousel = () => {
                 </div>
               </nav>
               
-              <figure ref={tagfigure}>
+              <figure ref={tagfigure} className={classes.video}>
                   <iframe
                     title="hero"
                     src={`https://player.twitch.tv/?channel=${creator[0]}&autoplay=${auto0}`}
@@ -358,7 +361,6 @@ const MainCarousel = () => {
                       </svg>
                   </div>
                 </nav>
-            
             </div>
             </div>
           </div>

--- a/client/src/organisms/main/Main/views/Carousel/MainCarousel.jsx
+++ b/client/src/organisms/main/Main/views/Carousel/MainCarousel.jsx
@@ -346,9 +346,6 @@ const MainCarousel = () => {
             </div>
             </div>
           </div>
-          {/* <div className="titleWrapper">
-          {title && <h1 className="nowCreatorTitle">OnAD와 함께하는 크리에이터입니다</h1>}
-          </div> */}
         </>
         ) 
       : (null)

--- a/client/src/organisms/main/Main/views/Carousel/MainCarousel.jsx
+++ b/client/src/organisms/main/Main/views/Carousel/MainCarousel.jsx
@@ -90,9 +90,9 @@ const MainCarousel = () => {
 
     setupCarousel(n, parseFloat(getComputedStyle(videos[0]).width));
     
-    window.addEventListener('resize', () => { 
-      setupCarousel(n, parseFloat(getComputedStyle(videos[0]).width)) 
-    });
+    // window.addEventListener('resize', () => { 
+    //   setupCarousel(n, parseFloat(getComputedStyle(videos[0]).width)) 
+    // });
 
     function setupCarousel(n, s) {
       let	

--- a/client/src/organisms/main/Main/views/Categories/ProductCategoriesImageButton.jsx
+++ b/client/src/organisms/main/Main/views/Categories/ProductCategoriesImageButton.jsx
@@ -131,10 +131,7 @@ const ProductCategoriesDetail = (props) => {
         >
           <div className={classes.imageButton}>
             <img src={image.url} className={classes.imageSrc} alt={image.title} />
-            <Typography
-              color="inherit"
-              className={classes.imageTitle}
-            >
+            <div className={classes.imageTitle}>
               {image.title}
               <br />
               <br />
@@ -144,7 +141,7 @@ const ProductCategoriesDetail = (props) => {
                   <p key={row} style={{ marginTop: 1, marginBottom: 1 }}>{`${row}`}</p>
                 ))}
               </div>
-            </Typography>
+            </div>
           </div>
 
         </ButtonBase>

--- a/client/src/organisms/main/Main/views/Categories/ProductCategoriesImageButton.jsx
+++ b/client/src/organisms/main/Main/views/Categories/ProductCategoriesImageButton.jsx
@@ -4,7 +4,7 @@ import { withStyles } from '@material-ui/core/styles';
 import ButtonBase from '@material-ui/core/ButtonBase';
 import Grow from '@material-ui/core/Grow';
 import useScrollTrigger from '@material-ui/core/useScrollTrigger';
-import Typography from '../../components/Typography';
+
 
 const styles = theme => ({
   imageWrapper: {

--- a/client/src/pages/main/Policy.jsx
+++ b/client/src/pages/main/Policy.jsx
@@ -16,9 +16,9 @@ const useStyles = makeStyles((theme) => ({
     marginTop: 70
   },
   contentBox: {
-    width: 980,
+    width: '80%',
     margin: '0px auto',
-    minHeight: 924,
+    wordBreak: 'keep-all'
   },
   policyTitle: {
     paddingTop: '10px',    

--- a/service/routes/dashboard/creator/creator.js
+++ b/service/routes/dashboard/creator/creator.js
@@ -37,6 +37,8 @@ router.get('/income', (req, res) => {
     .then((row) => {
       const result = row.result[0];
       result.date = result.date.toLocaleString();
+      const deciphedAccountNum = encrypto.decipher(result.creatorAccountNumber);
+      result.creatorAccountNumber = deciphedAccountNum;
       res.json(result);
     })
     .catch((errorData) => {

--- a/service/routes/dashboard/creator/creator.js
+++ b/service/routes/dashboard/creator/creator.js
@@ -2,7 +2,6 @@
 const express = require('express');
 const doQuery = require('../../../model/doQuery');
 const encrypto = require('../../../encryption');
-
 const router = express.Router();
 
 // sub router


### PR DESCRIPTION
1. 정책 페이지 컨텐츠 폭 수정 및 단어 단위로 word-break되도록 수정

2. 캐러셀 컴포넌트에서 다른 컴포넌트로 바뀔 때 unmout 로직 적용.

(1) 첫번째 가장 큰 문제는 window 전역객체에 resize 이벤트에 대한 캐러셀 폭 수정 및 회전이 일어나게 되어있었다.
따라서,  다른 페이지로 넘어갈 때에도 resize함수가 실행되는데,  이때, 캐러셀 회전에 대한 함수 내부에서 해당 엘리먼트를 식별할 수 없으므로 에러가 나타나는 현상이었다.

(2) 캐러셀 페이지의 useEffect 코드에
~~~js
setTimeout(function() {
            setTitle(true);
          }, 2000)
~~~
내용이 있었는데,  브라우저 API 기능 중 하나인 abort와 axios의 cancelToken을 통해 해당 컴포넌트가 언마운트 될 시에 호출되던 함수를 해제시키고, axios 요청을 취소하였다. 하지만 위의 setTimeout가 잔여하고 있어서 메모리 누수가 일어난다는 오류를 띄웠다. 위의 내용을 삭제시키니 바로 해결!

(3) 따라서, 전역객체에 resize에 대한 이벤트리스너가 등록되어 있다는 얘긴데... removeEventListener를 해도 동작이 잘 되지 않는다.... 이를 어떻게 해결해야 할까.... 당장은 큰 문제없지만 캐러셀 페이지에서만 이벤트가 발동해야하는데 다른 페이지에서도 발동이 가능하다는 것은 해당 어플리케이션의 백그라운드에서 필요없는 함수 동작이 일어난다는 것이 너무 비효율 적이다. 오류는 일어나지 않게 해놓았지만 차후에 공부해서 코드를 좀 더 세련되고 성능에 방해되지 않게 리팩토링 해야할 듯