### PR TITLE
[UPDATE #4.2] 마케터 대시보드 컴포넌트 렌더링 부스팅

### DIFF
--- a/client/src/organisms/marketer/Dashboard/CanvasForChart.jsx
+++ b/client/src/organisms/marketer/Dashboard/CanvasForChart.jsx
@@ -5,8 +5,10 @@ import ChartTabs from './chart/ChartTabs';
 import CreatorsChart from './chart/CreatorsChart';
 import ReChartBar from '../../../atoms/Chart/ReChartBar';
 
+
 export default function CanvasForChart(props) {
-  const { creatorsData, valueChartData, broadCreatorData } = props;
+  const { valueChartData, broadCreatorData } = props;
+
   const [tabValue, setTabValue] = React.useState(0);
   function handleTabChange(event, newValue) {
     setTabValue(newValue);
@@ -26,7 +28,10 @@ export default function CanvasForChart(props) {
           <ReChartBar data={valueChartData.payload} />
           )}
           {tabValue === 1 && (
-            <CreatorsChart creatorsData={creatorsData} broadCreatorData={broadCreatorData} />
+            (!broadCreatorData.loading && broadCreatorData.payload)
+              && (
+                <CreatorsChart broadCreatorData={broadCreatorData} />
+              )
           )}
         </div>
 

--- a/client/src/organisms/marketer/Dashboard/chart/CreatorsChart.jsx
+++ b/client/src/organisms/marketer/Dashboard/chart/CreatorsChart.jsx
@@ -1,21 +1,41 @@
 import React from 'react';
 import {
-  Grid, Avatar, Chip, Typography, Badge
+  Grid, Avatar, Chip, Typography, Badge, CircularProgress
 } from '@material-ui/core';
 import makeStyles from '@material-ui/core/styles/makeStyles';
-import Skeleton from '@material-ui/lab/Skeleton';
+// import Skeleton from '@material-ui/lab/Skeleton';
 import Error from '@material-ui/icons/Error';
 import ReChartPie from '../../../../atoms/Chart/ReChartPie';
+
+// usehook
+import useFetchData from '../../../../utils/lib/hooks/useFetchData';
 
 const useStyles = makeStyles(theme => ({
   chip: {
     margin: theme.spacing(0.5)
+  },
+  loading: {
+    paddingTop: theme.spacing(3),
+    paddingBottom: theme.spacing(3)
+  },
+  statement: {
+    fontSize: 15,
+    fontWeight: 700,
+    textAlign: 'center',
+    marginBottom: '3px'
+  },
+  sub: {
+    fontSize: 13,
+    fontWeight: 700,
+    textAlign: 'center',
+    marginBottom: theme.spacing(2)
   }
 }));
 
 export default function CustomPieChart(props) {
   const classes = useStyles();
-  const { creatorsData, broadCreatorData } = props;
+  const { broadCreatorData } = props;
+  const creatorsData = useFetchData('/api/dashboard/marketer/report/creators');
 
   const [activeIndex, setActiveIndex] = React.useState(0);
   const onPieEnter = (d, index) => {
@@ -24,30 +44,39 @@ export default function CustomPieChart(props) {
 
   return (
     <Grid container>
-
-      {!broadCreatorData.loading && !creatorsData.loading
-         && broadCreatorData.payload.length === 0 && creatorsData.payload.length === 0 && (
-         <Grid
-           item
-           xs={12}
-           style={{
-             height: 350, display: 'flex', justifyContent: 'center', alignItems: 'center'
-           }}
-         >
-           <div style={{ position: 'absolute' }}>
-             <Error style={{ fontSize: 128, opacity: 0.6, zIndex: 0 }} color="secondary" />
-           </div>
-           <div>
-             <Grid container direction="column" justify="center" alignItems="center">
-               <Typography style={{ zIndex: 1 }}>
+      {(creatorsData.loading) && (
+        <Grid item xs={12} className={classes.loading}>
+          <Typography className={classes.statement}>
+          송출 크리에이터 데이터를 로드하고 있습니다.
+          </Typography>
+          <Typography className={classes.sub} color="textSecondary">
+            접속환경에 따라 수 분이 걸릴 수 있습니다.
+          </Typography>
+          <div style={{ textAlign: 'center' }}><CircularProgress /></div>
+        </Grid>
+      )}
+      {!creatorsData.loading && broadCreatorData.payload.length === 0 && creatorsData.payload.length === 0 && (
+      <Grid
+        item
+        xs={12}
+        style={{
+          height: 350, display: 'flex', justifyContent: 'center', alignItems: 'center'
+        }}
+      >
+        <div style={{ position: 'absolute' }}>
+          <Error style={{ fontSize: 128, opacity: 0.6, zIndex: 0 }} color="secondary" />
+        </div>
+        <div>
+          <Grid container direction="column" justify="center" alignItems="center">
+            <Typography style={{ zIndex: 1 }}>
             아직 광고를 송출한 크리에이터가 없어요.
-               </Typography>
-               <Typography style={{ zIndex: 1 }}>
+            </Typography>
+            <Typography style={{ zIndex: 1 }}>
             배너와 캠페인을 등록해 광고를 집행해보세요.
-               </Typography>
-             </Grid>
-           </div>
-         </Grid>
+            </Typography>
+          </Grid>
+        </div>
+      </Grid>
       )}
 
       <Grid item xs={12} lg={6}>
@@ -66,12 +95,8 @@ export default function CustomPieChart(props) {
       </Grid>
 
       <Grid item xs={12} lg={6} style={{ overflow: 'hidden' }}>
-        {(creatorsData.loading || broadCreatorData.loading) && (
-          <Skeleton height="100%" />
-        )}
-
-        {!creatorsData.loading && !broadCreatorData.loading
-        && creatorsData.payload.length > 0 && broadCreatorData.payload && (
+        {!creatorsData.loading
+        && creatorsData.payload.length > 0 && (
           <Grid container>
             <Grid item xs={12}>
               <Typography variant="caption">* 아이콘 클릭시 해당 크리에이터의 채널로 이동됩니다.</Typography>

--- a/client/src/pages/marketer/Dashboard.jsx
+++ b/client/src/pages/marketer/Dashboard.jsx
@@ -24,7 +24,8 @@ export default function Dashboard() {
   const campaignData = useFetchData('/api/dashboard/marketer/campaign/new');
   const onOffData = useFetchData('/api/dashboard/marketer/onoff');
   const normalData = useFetchData('/api/dashboard/marketer/normal');
-  const creatorsData = useFetchData('/api/dashboard/marketer/report/creators');
+  const countsData = useFetchData('/api/dashboard/marketer/report/counts');
+
   const valueChartData = useFetchData('/api/dashboard/marketer/campaign/chart');
   const broadCreatorData = useFetchData('/api/dashboard/marketer/broadcast/creator');
   const actionLogData = useFetchData('/api/dashboard/marketer/actionlog');
@@ -32,14 +33,13 @@ export default function Dashboard() {
   return (
     <div className={classes.root}>
       {(normalData.loading || campaignData.loading
-        || onOffData.loading || creatorsData.loading
+        || onOffData.loading
         || valueChartData.loading
         || actionLogData.loading) ? (
           <ReportLoading />
         ) : (
           <div>
             {normalData.payload && campaignData.payload
-          && creatorsData.payload
           && valueChartData.payload && (
           <Grid container spacing={2}>
             <Grid item xs={12} md={6} lg={3}>
@@ -80,7 +80,7 @@ export default function Dashboard() {
                 <Grid item xs={12} sm={6} lg={3}>
                   <Grow in timeout={{ enter: 1500 }}>
                     <DescCard data={{
-                      title: '송출크리에이터수', value: creatorsData.payload.length, unit: '명'
+                      title: '송출크리에이터수', value: countsData.payload.counts, unit: '명'
                     }}
                     />
                   </Grow>
@@ -95,7 +95,6 @@ export default function Dashboard() {
                 <Grid item xs={12}>
                   <CanvasForChart
                     valueChartData={valueChartData}
-                    creatorsData={creatorsData}
                     broadCreatorData={broadCreatorData}
                   />
                 </Grid>

--- a/service/routes/dashboard/marketer/sub/campaign.js
+++ b/service/routes/dashboard/marketer/sub/campaign.js
@@ -58,6 +58,24 @@ router.get('/new', (req, res) => {
   and date > ?
   `;
 
+  // const mergedQuery = `
+  // select CL.campaignId, campaignName, optionType, priorityType, regiDate, onOff, bannerSrc, dailyLimit,  CL.campaignId, sum(cashFromMarketer) as dailysum
+  // from campaignLog
+  // right join
+  // (
+  // SELECT campaign.campaignId, campaignName, optionType, priorityType, campaign.regiDate, onOff, bannerSrc, dailyLimit
+  // FROM campaign
+  // JOIN bannerRegistered AS br
+  // ON br.bannerId = campaign.bannerId
+  // WHERE campaign.marketerId = ?
+  // AND deletedState = 0
+  // ) as CL
+  // on campaignLog.campaignId = CL.campaignId
+  // and date > ?
+  // group by campaignLog.campaignId
+  // ORDER BY CL.regiDate DESC
+  // `;
+
   doQuery(query, [marketerId]).then((row) => {
     if (row.result && !row.error) {
       Promise.all(

--- a/service/routes/dashboard/marketer/sub/report.js
+++ b/service/routes/dashboard/marketer/sub/report.js
@@ -132,6 +132,31 @@ router.get('/cpm', (res, req) => {
     });
 });
 
+router.get('/counts', (req, res) => {
+  const marketerId = req._passport.session.user.userid;
+  const query = `
+  select count( DISTINCT creatorId ) as counts
+  from 
+  campaignLog as CL
+  inner join
+  (select  campaignId
+  from campaign
+  where marketerId= ?
+  ) as CP
+  on CL.campaignId = CP.campaignId
+  `;
+
+  doQuery(query, [marketerId])
+    .then((row) => {
+      if (!row.error && row.result) {
+        res.send({ counts: row.result[0].counts });
+      }
+    })
+    .catch((err) => {
+      console.log(err);
+    });
+});
+
 // creator 정보 - CPM: 송출 크리에이터
 router.get('/creators', (req, res) => {
   const marketerId = req._passport.session.user.userid;


### PR DESCRIPTION
- 대시보드에서 waterfall이 가장 긴 송출크리에이터 요청을 해당 그래프 컴포넌트 렌더링 시로 변경
- campaignLog table index설정

약 3~4 초의 시간절감