### PR TITLE
[HOTFIX] 마케터 계정관리에서 이메일 변경시 미반영 오류

### DIFF
--- a/client-ts/src/organisms/mypage/marketer/office/profile/UserDataUpdateDialog.tsx
+++ b/client-ts/src/organisms/mypage/marketer/office/profile/UserDataUpdateDialog.tsx
@@ -177,6 +177,9 @@ const UserDataUpdateDialog = (props: UserDataUpdateDialogProps): JSX.Element => 
         case 'phone':
           return formattedPhone;
         case 'mail':
+          if(marketerCustomDomain !== ''){
+            return `${state.email}@${marketerCustomDomain}`;
+          }
           return `${state.email}@${state.domain}`;
         case 'name':
           return state.name;
@@ -184,8 +187,11 @@ const UserDataUpdateDialog = (props: UserDataUpdateDialogProps): JSX.Element => 
           return '';
       }
     };
+
     const value = getValue(type);
     doPatchRequest({ type, value });
+
+    setCustomDomain('');
     snack.handleOpen();
   };
 


### PR DESCRIPTION
- 이메일 직접입력으로 입력하여 변경시에, 입력한 값이 아닌 선택된 '직접입력'이 들어가는 오류

> 직접입력한 값을 대신 추가하여 저장