### PR TITLE
공지사항 방송인/광고주 구분 추가

### DIFF
--- a/client-ts/public/index.html
+++ b/client-ts/public/index.html
@@ -7,7 +7,8 @@
   <meta property="og:url" content="https://onad.io" />
   <meta property="og:description"
     content="ONAD는 1인 미디어 실시간 방송에 배너광고를 송출하는 플랫폼입니다. 크리에이터는 ONAD를 통해 추가 수익을, 광고주는 온애드를 통해 효율적인 광고 채널을 확보할 수 있습니다." />
-  <meta property="og:image" content="https://onad-static-files.s3.ap-northeast-2.amazonaws.com/onad_logo_blue.jpg" />
+  <meta property="og:image"
+    content="https://onad-static-files.s3.ap-northeast-2.amazonaws.com/open-graph/logo_opengraph.png" />
   <!-- 결제모듈('iamport'서비스 이용) -->
   <!-- jQuery -->
   <script type="text/javascript" src="https://code.jquery.com/jquery-1.12.4.min.js"></script>

--- a/client-ts/src/organisms/mypage/shared/notice/NoticeContents.tsx
+++ b/client-ts/src/organisms/mypage/shared/notice/NoticeContents.tsx
@@ -12,6 +12,7 @@ const useStyles = makeStyles((theme) => ({
     fontWeight: theme.typography.body1.fontWeight,
   },
   container: { padding: theme.spacing(4) },
+  chip: { margin: theme.spacing(0, 0.5, 0, 0) },
 }));
 
 interface NoticeContentsProps {
@@ -24,7 +25,8 @@ export default function NoticeContents({
   return (
     <Paper>
       <div className={classes.container}>
-        <Chip color="primary" label={selectedNotice.topic} />
+        <Chip color="primary" label={selectedNotice.topic} className={classes.chip} />
+        <Chip color="default" label={selectedNotice.target} className={classes.chip} />
         <Typography variant="h6">{selectedNotice.title}</Typography>
         <Typography variant="body2">
           {new Date(selectedNotice.regiDate).toLocaleString()}

--- a/client-ts/src/organisms/mypage/shared/notice/NoticeTable.tsx
+++ b/client-ts/src/organisms/mypage/shared/notice/NoticeTable.tsx
@@ -7,7 +7,7 @@ import { lighten, makeStyles, Paper } from '@material-ui/core';
 import CustomDataGrid from '../../../../atoms/Table/CustomDataGrid';
 
 const useStyles = makeStyles((theme) => ({
-  new: { color: theme.palette.secondary.main },
+  new: { color: theme.palette.primary.main },
   title: {
     cursor: 'pointer',
     '&:hover': { textDecoration: 'underline' },

--- a/client-ts/src/organisms/mypage/shared/notice/NoticeTable.tsx
+++ b/client-ts/src/organisms/mypage/shared/notice/NoticeTable.tsx
@@ -41,6 +41,7 @@ export interface NoticeData {
   regiDate: string;
   title: string;
   contents?: string;
+  target: string;
 }
 
 export default function NoticeTable({
@@ -71,8 +72,16 @@ export default function NoticeTable({
               ),
             },
             {
-              width: 150,
+              width: 80,
               headerName: '구분',
+              field: 'target',
+              renderCell: (_data): React.ReactElement => (
+                <Typography variant="body2" noWrap>{_data.row.target}</Typography>
+              )
+            },
+            {
+              width: 150,
+              headerName: '카테고리',
               field: 'topic',
               renderCell: (_data): React.ReactElement => (
                 <Typography variant="body2" noWrap>

--- a/server/routes/notice/index.ts
+++ b/server/routes/notice/index.ts
@@ -12,23 +12,21 @@ router.route('/')
     responseHelper.middleware.withErrorCatch(async (req, res, next) => {
       const query = `
       SELECT
-        code AS id ,code, topic, title, contents, regiDate
+        code AS id ,code, topic, title, contents, regiDate, target
       FROM publicNotice
-      ORDER BY code DESC
+      ORDER BY topic = "필독" DESC, code DESC
       `;
       interface NoticeResult {
         code: string | number;
         topic: string | number;
         title: string;
+        target: string;
         contents: string;
         regiDate: string | Date;
       }
 
       const rows = await doQuery<NoticeResult[]>(query);
-      const MustRows = rows.result.filter((x: NoticeResult) => x.topic === '필독');
-      const NotMustRows = rows.result.filter((x: NoticeResult) => x.topic !== '필독');
-      const result = MustRows.concat(NotMustRows);
-      responseHelper.send(result, 'get', res);
+      responseHelper.send(rows.result, 'get', res);
     })
   )
   .all(responseHelper.middleware.unusedMethod);


### PR DESCRIPTION
### DB

- [x]  테이블 독자구분 컬럼 생성
    - 컬럼명 `target`, 방송인/광고주/공통
- [x]  기존 공지사항 독자 구분 설정
    - 공지사항
    - 결제/계산서/정산
    - 업데이트
    - 시스템 점검
    - 이외의 필돗/이벤트의 경우 해당하는 타겟으로 설정함.

### 관리자페이지 백엔드

- [x]  조회 쿼리 target 추가
- [x]  조회 쿼리 쿼리상에서 "필독" 정렬되도록 수정
- [x]  수정 쿼리 target 추가
- [x]  생성 쿼리 target 추가

### 관리자 페이지 프론트엔드

- [x]  공지사항 목록에 방송인/광고주 구분 추가
- [x]  개별 공지사항 글 preview에 구분 추가
- [x]  공지사항 생성 / 수정
    - [x]  공지사항 방송인/광고주 구분 선택 SelectBox 생성
    - [x]  제목에 공지사항 카테고리 "[결제/계산서]" 와 같이 들어가는 기능 삭제

### 관리자페이지 배포 admin.onad.io

- [x]  백엔드 도커빌드
- [x]  프론트엔드 리액트 빌드 및 도커빌드
- [x]  백엔드 서버 새로운 도커 컨테이너를 바라보도록 수정
- [x]  프론트엔드 서버 새로운 도커 컨테이너를 바라보도록 수정

### 온애드 프론트엔드 마이페이지 공지사항 탭

- [x]  공지사항 목록 방송인/광고주 구분 추가
- [x]  공지사항 개별글 방송인/광고주 구분 추가
- [x] 공지사항 목록 NEW 아이콘 색상 부색상에서 주색상으로 변경
