### PR TITLE
마이페이지 그래프 가독성 수정

### DIFF
--- a/client-ts/src/atoms/Chart/ReChartBar.tsx
+++ b/client-ts/src/atoms/Chart/ReChartBar.tsx
@@ -69,10 +69,14 @@ export default function ReChartBar<DataType extends IncomeChartData>({
           }}
         >
           <CartesianGrid strokeDasharray="3 3" />
-          <XAxis dataKey={xAxisDataKey} />
-          <YAxis />
+          <XAxis dataKey={xAxisDataKey} tick={{ fill: theme.palette.text.secondary }} />
+          <YAxis tick={{ fill: theme.palette.text.secondary }} />
           <Tooltip
-            contentStyle={{ backgroundColor: theme.palette.background.paper }}
+            contentStyle={{
+              backgroundColor: theme.palette.common.white,
+              color: theme.palette.common.black,
+              fontWeight: theme.typography.fontWeightBold
+            }}
             cursor={{ stroke: theme.palette.primary.main, strokeWidth: 1 }}
             labelFormatter={tooltipLabelFormatter}
             formatter={tooltipFormatter}
@@ -80,6 +84,9 @@ export default function ReChartBar<DataType extends IncomeChartData>({
           {legend && (
             <Legend
               iconType="circle"
+              wrapperStyle={{
+                fontWeight: theme.typography.fontWeightRegular
+              }}
               formatter={legendFormatter}
             />
           )}

--- a/client-ts/src/atoms/Chart/ReChartPie.tsx
+++ b/client-ts/src/atoms/Chart/ReChartPie.tsx
@@ -3,6 +3,7 @@ import {
   PieChart, Pie, Sector, Cell,
   ResponsiveContainer, Legend
 } from 'recharts';
+import shortid from 'shortid';
 import COLORS from './chartTheme';
 
 interface RenderActiveShapeProps {
@@ -120,7 +121,7 @@ export default function CustomPieChart<DataType>({
             {data.map<JSX.Element>(
               (entry, index) => (
                 <Cell
-                  key={`cell_${index}`}
+                  key={shortid.generate()}
                   fill={COLORS.pie[index % COLORS.pie.length]}
                 />
               )


### PR DESCRIPTION
- [x]  다크모드 관계없이 툴팁 배경을 흰색으로 고정. (주색상인 파랑색이 다크모드 배경에서 잘 보이지 않음.)
- [x]  툴팁 글자 fontWeight 수정
- [x]  아래 범례 글자 가독성 향상 (fontWeight 조절)
- [x]  x축,y축 라벨 가독성 향상 (색상 조정)