### PR TITLE
Hwasurr cps tracker 및 배너광고송출프로그램 변경

### DIFF
--- a/calculator/app.js
+++ b/calculator/app.js
@@ -1,9 +1,15 @@
 require('dotenv').config(); // 환경변수를 위해. dev환경: .env 파일 / production환경: docker run의 --env-file인자로 넘김.
-require('./javascripts/calculation_v.4')()
-// CPC계산
-  .then(require('./javascripts/trackingCalculator_v.3'))
-// 추천인 코드 계산
-  .then(require('./javascripts/referralCodeCalculator'))
-  .then(() => {
-    process.exit(0);
-  });
+// require('./javascripts/calculation_v.4')()
+// // CPC계산
+//   .then(require('./javascripts/trackingCalculator_v.3'))
+// // 추천인 코드 계산
+//   .then(require('./javascripts/referralCodeCalculator'))
+//   .then(() => {
+//     process.exit(0);
+//   });
+
+
+require('./javascripts/cpsCalculator')()
+  .then(() => console.log('done'))
+  .then(() => process.exit(0))
+  .catch((err) => console.error(err));

--- a/calculator/app.js
+++ b/calculator/app.js
@@ -1,15 +1,15 @@
-require('dotenv').config(); // 환경변수를 위해. dev환경: .env 파일 / production환경: docker run의 --env-file인자로 넘김.
-// require('./javascripts/calculation_v.4')()
-// // CPC계산
-//   .then(require('./javascripts/trackingCalculator_v.3'))
-// // 추천인 코드 계산
-//   .then(require('./javascripts/referralCodeCalculator'))
-//   .then(() => {
-//     process.exit(0);
-//   });
+// 환경변수를 위해. dev환경: .env 파일 / production환경: docker run의 --env-file인자로 넘김.
+require('dotenv').config();
 
+require('./javascripts/calculation_v.4')()
+  // CPC계산
+  .then(require('./javascripts/trackingCalculator_v.3'))
+  // 추천인 코드 계산
+  .then(require('./javascripts/referralCodeCalculator'))
+  .then(() => {
+    process.exit(0);
+  });
 
+// CPS 계산
 require('./javascripts/cpsCalculator')()
-  .then(() => console.log('done'))
-  .then(() => process.exit(0))
-  .catch((err) => console.error(err));
+  .then(() => process.exit(0));

--- a/calculator/javascripts/cpsCalculator.js
+++ b/calculator/javascripts/cpsCalculator.js
@@ -1,0 +1,84 @@
+/* eslint-disable max-len */
+const doQuery = require('../model/calculatorQuery');
+
+/**
+ * 주문 목록 중, 
+ * 주문의 상태가 "구매확정"(6) 이며, 계산완료플래그가 false인 목록을 불러옵니다.
+ * 이 목록은 계산의 대상입니다.
+ * @returns [
+  {
+    id: 1,
+    campaignId: 'gubgoo_c34',
+    merchandiseId: 34,
+    orderPrice: 10000,
+    calculateDoneFlag: 0,
+    marketerId: 'gubgoo',
+    name: '상품등록테스트',
+    targetCreatorId: 130096343,
+    creatorName: '화수르',
+    statusString: '구매확정'
+    }, ...
+  ]
+ */
+const getTargets = async () => {
+  const query = `
+  SELECT
+    MO.id, campaignId, merchandiseId, orderPrice, calculateDoneFlag,
+    MR.marketerId, MR.name,
+    MOC.creatorId AS targetCreatorId, creatorName,
+    statusString
+  FROM merchandiseOrders AS MO
+  JOIN merchandiseRegistered AS MR ON MR.id = MO.merchandiseId
+  JOIN merchandiseOrderStatuses AS MOS ON MOS.statusNumber = MO.status
+  LEFT JOIN merchandiseOrderComments AS MOC ON MO.id = MOC.orderId
+  LEFT JOIN creatorInfo ON MOC.creatorId = creatorInfo.creatorId
+  WHERE statusString = ? AND calculateDoneFlag = ?`;
+
+  const { result } = await doQuery(query, ['구매확정', false]);
+  return result;
+};
+
+/**
+ * CPS 캠페인 계산 작업을 실행합니다.
+ * 1. 캠페인 계산 로그 처리 (campaignLog - campaignId, creatorId, type=CPS, cashToCreator, salesIncomeToMarketer)
+ * 2. 광고주 판매대금 처리 (marketerSalesIncome - marketerId, 추가금액)
+ * 3. 방송인 수익금 처리 (creatorIncome - creatorId, 추가금액)
+ * 4. 모두 완료 후, 주문의 계산완료플래그를 true로 처리 (merchandiseOrders - calculateDoneFlag)
+ */
+const calculate = () => {
+
+};
+
+/**
+ * ### CPS 계산 정책
+ * 
+ * 1. 방송인 A로부터 유입된 시청자가 구입 + 인증(리뷰or자랑하기)**글을 남기고** 구매완료 시
+ *    - ⇒ 광고주 70 %, 방송인 A 20 %, 온애드 10 %
+ * 
+ * 2. 방송인 A로부터 유입된 시청자가 구입 + 인증(리뷰or자랑하기)**글을 남기지 않고** 구매완료 시
+ *    - **⇒ 광고주 90 %, 온애드 10 %**
+ */
+async function cpsCalculate() {
+  console.info('CPS 판매 대금 계산을 시작합니다.');
+
+  // Find all referral code log list
+  const targets = await getTargets().catch((err) => console.error(`CPS 계산 대상 목록 가져오는 도중 오류 - ${err}`));
+  console.info('CPS 판매 대금 계산 타겟 수: ', targets.length);
+  console.log(targets);
+
+  // return Promise.all(
+  //   targets.map((target) => calculate({
+  //     referralCode: target.referralCode,
+  //     referringCreatorId: target.referringCreatorId,
+  //     referredCreatorId: target.referredCreatorId,
+  //   }))
+  // )
+  //   .then(() => console.log(`[${new Date().toLocaleString()}] 추천인 코드 이벤트 계산을 완료하였습니다.`))
+  //   .catch((err) => {
+  //     console.log(`[${new Date().toLocaleString()}] 추천인 코드 이벤트 계산 중 오류 발생`);
+  //     console.error(err);
+  //     throw err;
+  //   });
+}
+
+module.exports = cpsCalculate;

--- a/calculator/javascripts/cpsCalculator.js
+++ b/calculator/javascripts/cpsCalculator.js
@@ -1,6 +1,35 @@
 /* eslint-disable max-len */
 const doQuery = require('../model/calculatorQuery');
 
+const CREATOR_FEERATE = 0.2;
+const MARKETER_FEERATE_PROMOTED_BY_CREATOR = 0.7;
+const MARKETER_FEERATE_DEFAULT = 0.9;
+
+/**
+   * 각 유저별 계산 대금을 구합니다. 리뷰/자랑하기/응원하기 글의 대상인 방송인이 있는 지 여부를 기준으로
+   * 계산 대금은 다르게 계산됩니다.
+   * @author hwasurr
+   * @param { number } orderPrice 계산이 필요한 판매 대금
+   * @param { boolean } isCreatorExists 리뷰/자랑하기/응원하기 글의 대상인 방송인이 있는지 여부
+   * 1. 방송인 A로부터 유입된 시청자가 구입 + 인증(리뷰or자랑하기)**글을 남기고** 구매완료 시
+   *    - **⇒ 광고주 70 %, 방송인 A 20 %, 온애드 10 %**
+   * 
+   * 2. 방송인 A로부터 유입된 시청자가 구입 + 인증(리뷰or자랑하기)**글을 남기지 않고** 구매완료 시
+   *    - **⇒ 광고주 90 %, 온애드 10 %**
+   */
+const getCashesCalculated = (totalOrderPrice, isCreatorExists) => {
+  if (isCreatorExists) { // 1 번의 경우
+    const cashToCreator = totalOrderPrice * CREATOR_FEERATE;
+    const salesIncomeToMarketer = totalOrderPrice * MARKETER_FEERATE_PROMOTED_BY_CREATOR;
+    return {
+      cashToCreator, salesIncomeToMarketer
+    };
+  }
+  const cashToCreator = 0;
+  const salesIncomeToMarketer = totalOrderPrice * MARKETER_FEERATE_DEFAULT;
+  return { cashToCreator, salesIncomeToMarketer };
+};
+
 /**
  * 주문 목록 중, 
  * 주문의 상태가 "구매확정"(6) 이며, 계산완료플래그가 false인 목록을 불러옵니다.
@@ -39,14 +68,123 @@ const getTargets = async () => {
 };
 
 /**
+ * 계산 로그를 campaignLog에 적재
+ * @param {object} param0 campaignId, creatorId, cashToCreator, salesIncomeToMarketer
+ * @returns {number} inserted id
+ */
+const calculateCampaignLog = async ({
+  campaignId, creatorId, cashToCreator, salesIncomeToMarketer
+}) => {
+  const query = `
+    INSERT INTO campaignLog_copy (campaignId, creatorId, type, cashToCreator, salesIncomeToMarketer)
+    VALUES (?, ?, ?, ?, ?)
+  `;
+  const queryArray = [campaignId, creatorId, 'CPS', cashToCreator, salesIncomeToMarketer];
+
+  const { result } = await doQuery(query, queryArray);
+  if (result && result.insertId) return result.insertId;
+  return null;
+};
+
+/**
+ * 광고주 판매대금을 입력합니다.
+ * @author hwasurr
+ * @param {object} param0 marketerId, salesIncomeToMarketer
+ * @returns null | insertId
+ */
+const calculateMarketerSalesIncome = async ({
+  marketerId, salesIncomeToMarketer
+}) => {
+  const query = `
+  INSERT INTO marketerSalesIncome (marketerId, totalIncome, receivable) 
+  VALUES (
+    ?,
+    (SELECT IFNULL(MAX(totalIncome), 0) + ? AS totalIncome FROM marketerSalesIncome AS a WHERE marketerId = ? ORDER BY createDate DESC LIMIT 1),
+    (SELECT IFNULL(MAX(receivable), 0) + ? AS totalIncome FROM marketerSalesIncome AS a WHERE marketerId = ? ORDER BY createDate DESC LIMIT 1)
+  )`;
+  const queryArray = [marketerId, salesIncomeToMarketer, marketerId, salesIncomeToMarketer, marketerId];
+
+  const { result } = await doQuery(query, queryArray);
+  if (result && result.insertId) return result.insertId;
+  return null;
+};
+
+/**
+ * 방송인 수익금을 입력합니다. 주문의 리뷰/자랑하기/응원하기 글의 대상으로 크리에이터가 있는 경우에만 실행되어야 합니다.
+ * (merchandiseOrderComments 에 있는 지 여부에 따라 진행 여부가 판단됨)
+ * @author hwasaurr
+ * @param {object} param0 creatorId, cashToCreator
+ * @returns null | insertId
+ */
+const calculateCreatorIncome = async ({
+  creatorId, cashToCreator
+}) => {
+  if (creatorId && cashToCreator) {
+    const query = `
+    INSERT INTO creatorIncome_copy (
+      creatorId, creatorTotalIncome, creatorReceivable
+    ) VALUES (
+      ?,
+      (SELECT IFNULL(MAX(creatorTotalIncome), 0) + ? AS creatorTotalIncome FROM creatorIncome_copy AS a WHERE creatorId = ? ORDER BY date DESC LIMIT 1),
+      (SELECT IFNULL(MAX(creatorReceivable), 0) + ? AS creatorReceivable FROM creatorIncome_copy AS b WHERE creatorId = ? ORDER BY date DESC LIMIT 1)
+    )           `;
+    const queryArray = [creatorId, cashToCreator, creatorId, cashToCreator, creatorId];
+
+    const { result } = await doQuery(query, queryArray);
+    if (result && result.insertId) return result.insertId;
+    return null;
+  }
+  return null;
+};
+
+/**
+ * 해당 주문의 계산완료 여부를 "완료" 로 변경합니다.
+ * @param {object} param0 orderId
+ * @returns null | affectedRows
+ */
+const updateFlag = async ({ orderId }) => {
+  const query = 'UPDATE merchandiseOrders SET calculateDoneFlag = ? WHERE id = ?';
+  const queryArray = [1, orderId];
+
+  const { result } = await doQuery(query, queryArray);
+  if (result && result.affectedRows) return result.affectedRows;
+  return null;
+};
+
+/**
  * CPS 캠페인 계산 작업을 실행합니다.
  * 1. 캠페인 계산 로그 처리 (campaignLog - campaignId, creatorId, type=CPS, cashToCreator, salesIncomeToMarketer)
  * 2. 광고주 판매대금 처리 (marketerSalesIncome - marketerId, 추가금액)
  * 3. 방송인 수익금 처리 (creatorIncome - creatorId, 추가금액)
  * 4. 모두 완료 후, 주문의 계산완료플래그를 true로 처리 (merchandiseOrders - calculateDoneFlag)
  */
-const calculate = () => {
+const calculate = async ({
+  orderId, campaignId, merchandiseId, orderPrice, calculateDoneFlag, marketerId, name, targetCreatorId, creatorName, statusString
+}) => {
+  const { cashToCreator, salesIncomeToMarketer } = getCashesCalculated(orderPrice, !!targetCreatorId);
 
+  // * 1. 광고주 판매대금 처리 (marketerSalesIncome - marketerId, 추가금액)
+  await calculateMarketerSalesIncome({ marketerId, salesIncomeToMarketer });
+
+  // * 2. 방송인 수익금 처리 (creatorIncome - creatorId, 추가금액)
+  if (targetCreatorId) {
+    await calculateCreatorIncome({
+      creatorId: targetCreatorId, cashToCreator
+    });
+  }
+
+  // * 3. 캠페인 계산 로그 처리 (campaignLog - campaignId, creatorId, type=CPS, cashToCreator, salesIncomeToMarketer)
+  await calculateCampaignLog({
+    campaignId,
+    creatorId: targetCreatorId,
+    cashToCreator,
+    salesIncomeToMarketer
+  });
+
+  // * 4. 모두 완료 후, 주문의 계산완료플래그를 true로 처리 (merchandiseOrders - calculateDoneFlag)
+  await updateFlag({ orderId });
+
+  console.log(`[${new Date().toLocaleString()}] ${campaignId} 캠페인 (상품: ${name}, 방송인: ${creatorName || '없음'}) 계산 완료`);
 };
 
 /**
@@ -61,24 +199,29 @@ const calculate = () => {
 async function cpsCalculate() {
   console.info('CPS 판매 대금 계산을 시작합니다.');
 
-  // Find all referral code log list
   const targets = await getTargets().catch((err) => console.error(`CPS 계산 대상 목록 가져오는 도중 오류 - ${err}`));
   console.info('CPS 판매 대금 계산 타겟 수: ', targets.length);
-  console.log(targets);
 
-  // return Promise.all(
-  //   targets.map((target) => calculate({
-  //     referralCode: target.referralCode,
-  //     referringCreatorId: target.referringCreatorId,
-  //     referredCreatorId: target.referredCreatorId,
-  //   }))
-  // )
-  //   .then(() => console.log(`[${new Date().toLocaleString()}] 추천인 코드 이벤트 계산을 완료하였습니다.`))
-  //   .catch((err) => {
-  //     console.log(`[${new Date().toLocaleString()}] 추천인 코드 이벤트 계산 중 오류 발생`);
-  //     console.error(err);
-  //     throw err;
-  //   });
+  return Promise.all(
+    targets.map((target) => calculate({
+      orderId: target.id,
+      campaignId: target.campaignId,
+      merchandiseId: target.merchandiseId,
+      orderPrice: target.orderPrice,
+      calculateDoneFlag: target.calculateDoneFlag,
+      marketerId: target.marketerId,
+      name: target.name,
+      targetCreatorId: target.targetCreatorId,
+      creatorName: target.creatorName,
+      statusString: target.statusString,
+    }))
+  )
+    .then(() => console.log(`[${new Date().toLocaleString()}] CPS 판매 대금 계산을 모두 완료하였습니다.`))
+    .catch((err) => {
+      console.log(`[${new Date().toLocaleString()}] CPS 판매 대금 계산 중 오류 발생`);
+      console.error(err);
+      throw err;
+    });
 }
 
 module.exports = cpsCalculate;

--- a/client-ts/src/atoms/Switch/CampaignOnOffSwitch.tsx
+++ b/client-ts/src/atoms/Switch/CampaignOnOffSwitch.tsx
@@ -83,7 +83,9 @@ export default function CampaignOnOffSwitch(props: CampaignOnOffSwitchProps): Re
     if (campaign.optionType === CPS_OPTION_TYPE) {
       // 현재 off 상태이면서 온애드몰에 아직 업로드 되지 않았거나, 상품이 없거나, 온애드몰 사이트 URL이 아직 업로드 되지 않은 경우
       if (!campaign.onOff && (!campaign.merchandiseUploadState || !campaign.merchandiseId || !campaign.merchandiseItemSiteUrl)) {
-        handleOnOffDisable('아직 온애드몰에 상품이 업로드되지 않았습니다.');
+        let message = '아직 온애드몰에 상품이 업로드되지 않았습니다.';
+        if (campaign.merchandiseUploadState === 0 && campaign.merchandiseDenialReason) message = '상품이 거절된 캠페인입니다.';
+        handleOnOffDisable(message);
         return true;
       }
       // off 상태이면서 상품의 남은 재고가 없는 경우
@@ -94,7 +96,7 @@ export default function CampaignOnOffSwitch(props: CampaignOnOffSwitchProps): Re
       }
     }
     return false;
-  }, [campaign.confirmState, campaign.linkConfirmState, campaign.merchandiseId, campaign.merchandiseItemSiteUrl, campaign.merchandiseSoldCount, campaign.merchandiseStock, campaign.merchandiseUploadState, campaign.onOff, campaign.optionType]);
+  }, [campaign.confirmState, campaign.linkConfirmState, campaign.merchandiseDenialReason, campaign.merchandiseId, campaign.merchandiseItemSiteUrl, campaign.merchandiseSoldCount, campaign.merchandiseStock, campaign.merchandiseUploadState, campaign.onOff, campaign.optionType]);
 
   const switchButton = useMemo(() => (
     <Switch

--- a/client-ts/src/organisms/mypage/marketer/adManage/campaign/sub/CampaignInfoTabContents.tsx
+++ b/client-ts/src/organisms/mypage/marketer/adManage/campaign/sub/CampaignInfoTabContents.tsx
@@ -110,17 +110,17 @@ export default function CampaignInfoTabContents({
       {campaign.merchandiseId && campaign.merchandiseName
       && campaign.merchandiseStock && campaign.merchandiseSoldCount
       && (campaign.merchandiseStock - campaign.merchandiseSoldCount) <= 0 // 재고 소진으로 광고 진행 불가
-      && (
-        <Alert severity="info">
-          {campaign.merchandiseUploadState === MERCHANDISE_UPLOAD_SOLDOUT && (
-          <Typography>축하합니다!! 해당 캠페인의 판매가 모두 완료되었습니다.</Typography>
-          )}
-          <Typography variant="body2">
-            {`캠페인 ${campaign.campaignName} 의 상품 -> ${withJosa(campaign.merchandiseName, '이/가')} 재고 소진으로 인해 더이상 광고 진행이 불가한 상태입니다.`}
-          </Typography>
-          <Typography variant="body2">더 많은 상품 판매를 원하신다면 새로 상품을 등록하고 캠페인을 등록해주세요.</Typography>
-        </Alert>
-      )}
+        ? (
+          <Alert severity="info">
+            {campaign.merchandiseUploadState === MERCHANDISE_UPLOAD_SOLDOUT && (
+            <Typography>축하합니다!! 해당 캠페인의 판매가 모두 완료되었습니다.</Typography>
+            )}
+            <Typography variant="body2">
+              {`캠페인 ${campaign.campaignName} 의 상품 -> ${withJosa(campaign.merchandiseName, '이/가')} 재고 소진으로 인해 더이상 광고 진행이 불가한 상태입니다.`}
+            </Typography>
+            <Typography variant="body2">더 많은 상품 판매를 원하신다면 새로 상품을 등록하고 캠페인을 등록해주세요.</Typography>
+          </Alert>
+        ) : null}
 
       <article className={classes.article}>
         <Typography className={classes.bold}>현재 캠페인 상태</Typography>

--- a/client-ts/src/organisms/mypage/marketer/adManage/campaign/sub/CampaignInfoTabContents.tsx
+++ b/client-ts/src/organisms/mypage/marketer/adManage/campaign/sub/CampaignInfoTabContents.tsx
@@ -16,7 +16,7 @@ import renderBannerConfirmState, {
   CONFIRM_STATE_WAIT, CONFIRM_STATE_REJECTED, CONFIRM_STATE_CONFIRMED
 } from '../../../../../../utils/render_funcs/renderBannerConfirmState';
 import withJosa from '../../../../../../utils/withJosa';
-import renderMerchandiseUploadState, { MERCHANDISE_SOLDOUT } from '../../../../../../utils/render_funcs/renderMerchandiseUploadState';
+import renderMerchandiseUploadState, { MERCHANDISE_UPLOAD_SOLDOUT, MERCHANDISE_UPLOAD_WAITING } from '../../../../../../utils/render_funcs/renderMerchandiseUploadState';
 
 const useStyles = makeStyles((theme) => ({
   bold: { fontWeight: theme.typography.fontWeightBold },
@@ -84,7 +84,7 @@ export default function CampaignInfoTabContents({
 
       {/* CPS 캠페인의 상품이 아직 온애드몰에 업로드 되지 않은 경우 */}
       {campaign.merchandiseId && campaign.merchandiseName
-      && !(campaign.merchandiseUploadState || campaign.merchandiseItemSiteUrl)
+      && campaign.merchandiseUploadState === MERCHANDISE_UPLOAD_WAITING
       && (// 캠페인 정보 불러올 때 업로드 상태도 불러오게 변경한 이후 추가.
         <Alert severity="error">
           <Typography variant="body2">
@@ -94,13 +94,25 @@ export default function CampaignInfoTabContents({
         </Alert>
       )}
 
+      {/* CPS 캠페인의 상품이 아직 온애드몰에 업로드 되지 않은 경우 */}
+      {campaign.merchandiseId && campaign.merchandiseName
+      && campaign.merchandiseUploadState === 0
+      && (// 캠페인 정보 불러올 때 업로드 상태도 불러오게 변경한 이후 추가.
+        <Alert severity="error">
+          <Typography variant="body2">
+            {`캠페인 ${campaign.campaignName} 의 상품 -> ${withJosa(campaign.merchandiseName, '은/는')} 관리자에 의해 거절되었습니다.`}
+          </Typography>
+          <Typography variant="body2">{`사유는 ${campaign.merchandiseDenialReason}입니다. 문의는 support@onad.io 로 메일을 보내주세요.`}</Typography>
+        </Alert>
+      )}
+
       {/* CPS 캠페인의 상품이 재고 소진된 경우 */}
       {campaign.merchandiseId && campaign.merchandiseName
       && campaign.merchandiseStock && campaign.merchandiseSoldCount
       && (campaign.merchandiseStock - campaign.merchandiseSoldCount) <= 0 // 재고 소진으로 광고 진행 불가
       && (
         <Alert severity="info">
-          {campaign.merchandiseUploadState === MERCHANDISE_SOLDOUT && (
+          {campaign.merchandiseUploadState === MERCHANDISE_UPLOAD_SOLDOUT && (
           <Typography>축하합니다!! 해당 캠페인의 판매가 모두 완료되었습니다.</Typography>
           )}
           <Typography variant="body2">
@@ -121,7 +133,7 @@ export default function CampaignInfoTabContents({
         {campaign.merchandiseId && (
           <>
             <Typography>
-              {`상품 판매 상태 - ${renderMerchandiseUploadState(campaign.merchandiseUploadState || 0)}`}
+              {`상품 판매 상태 - ${renderMerchandiseUploadState(campaign.merchandiseUploadState || null)}`}
               {Boolean(campaign.merchandiseUploadState) && (
                 <CheckCircle className={classes.middle} fontSize="small" color="primary" />
               )}

--- a/client-ts/src/organisms/mypage/marketer/adManage/campaign/sub/MerchandiseOrderDialog.tsx
+++ b/client-ts/src/organisms/mypage/marketer/adManage/campaign/sub/MerchandiseOrderDialog.tsx
@@ -1,6 +1,6 @@
 import classnames from 'classnames';
 import {
-  Button, Chip, CircularProgress, makeStyles, Typography
+  Button, Chip, CircularProgress, Divider, makeStyles, Typography
 } from '@material-ui/core';
 import React, { useContext, useMemo, useState } from 'react';
 import SwipeableTextMobileStepper from '../../../../../../atoms/Carousel/Carousel';
@@ -9,7 +9,7 @@ import MarketerInfoContext from '../../../../../../context/MarketerInfo.context'
 import { getS3MerchandiseImagePath } from '../../../../../../utils/aws/getS3Path';
 import { useDialog, useGetRequest, usePatchRequest } from '../../../../../../utils/hooks';
 import renderOrderStatus, {
-  주문상태_출고준비완료, 주문상태_상품준비중, 주문상태_주문취소
+  주문상태_출고준비, 주문상태_상품준비, 주문상태_주문취소, 주문상태_배송완료, 주문상태_주문접수, 주문상태_출고완료
 } from '../../../../../../utils/render_funcs/renderOrderStatus';
 import { Merchandise, MerchandiseOrder } from '../../interface';
 import Snackbar from '../../../../../../atoms/Snackbar/Snackbar';
@@ -34,7 +34,8 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-export type OrderStatus = typeof 주문상태_상품준비중 | typeof 주문상태_출고준비완료 | typeof 주문상태_주문취소;
+export type OrderStatus = typeof 주문상태_출고준비
+|typeof 주문상태_상품준비|typeof 주문상태_주문취소|typeof 주문상태_배송완료|typeof 주문상태_주문접수|typeof 주문상태_출고완료;
 export interface MerchandiseDetailDialogProps {
   merchandiseOrder: MerchandiseOrder;
   open: boolean;
@@ -67,7 +68,7 @@ function MerchandiseOrderDialog({
   }
 
   // 남은 재고 수량 변수
-  const stockLeft = useMemo(
+  const availableStock = useMemo(
     () => merchandiseOrder.stock - (merchandiseOrder.merchandiseSoldCount || 0),
     [merchandiseOrder.merchandiseSoldCount, merchandiseOrder.stock]
   );
@@ -138,9 +139,9 @@ function MerchandiseOrderDialog({
               <Chip
                 size="small"
                 label={renderOrderStatus(merchandiseOrder.status)}
-                color={merchandiseOrder.status === 주문상태_상품준비중 ? 'primary' : 'default'}
+                color={merchandiseOrder.status === 주문상태_상품준비 ? 'primary' : 'default'}
                 className={classnames({
-                  [classes.success]: merchandiseOrder.status === 주문상태_출고준비완료,
+                  [classes.success]: [주문상태_출고준비, 주문상태_출고완료].includes(merchandiseOrder.status),
                 })}
               />
             </Typography>
@@ -152,7 +153,7 @@ function MerchandiseOrderDialog({
             </Typography>
             )}
             <Typography>{`주문 수량: ${merchandiseOrder.quantity}`}</Typography>
-            <Typography>{`남은 재고: ${stockLeft}`}</Typography>
+            <Typography>{`남은 재고: ${availableStock}`}</Typography>
             <Typography>
               {`총 주문 금액: ${
                 (merchandiseOrder.orderPrice
@@ -160,30 +161,41 @@ function MerchandiseOrderDialog({
               } 원`}
             </Typography>
 
+            <Divider />
+            <Typography>상태변경</Typography>
             <div className={classes.buttonSet}>
               <Button
                 className={classes.actionbutton}
                 variant="contained"
                 color="primary"
-                disabled={stockLeft === 0}
-                onClick={(): void => handleStatusSelect(주문상태_상품준비중)}
+                disabled={availableStock === 0}
+                onClick={(): void => handleStatusSelect(주문상태_상품준비)}
               >
-              상품준비중 상태로 변경
+                상품준비 상태로 변경
+              </Button>
+              <Button
+                className={classes.actionbutton}
+                color="primary"
+                variant="contained"
+                disabled={availableStock === 0}
+                onClick={(): void => handleStatusSelect(주문상태_출고준비)}
+              >
+                출고준비 상태로 변경
               </Button>
               <Button
                 className={classnames(classes.success, classes.actionbutton)}
                 variant="contained"
-                disabled={stockLeft === 0}
-                onClick={(): void => handleStatusSelect(주문상태_출고준비완료)}
+                disabled={availableStock === 0}
+                onClick={(): void => handleStatusSelect(주문상태_출고완료)}
               >
-              출고준비완료 상태로 변경
+                출고완료 상태로 변경
               </Button>
               <Button
                 className={classnames(classes.error, classes.actionbutton)}
                 variant="contained"
                 onClick={(): void => handleStatusSelect(주문상태_주문취소)}
               >
-              주문취소
+                주문취소
               </Button>
             </div>
             <Button fullWidth variant="contained" onClick={onClose}>닫기</Button>

--- a/client-ts/src/organisms/mypage/marketer/adManage/campaign/sub/MerchandiseOrderDialog.tsx
+++ b/client-ts/src/organisms/mypage/marketer/adManage/campaign/sub/MerchandiseOrderDialog.tsx
@@ -138,10 +138,10 @@ function MerchandiseOrderDialog({
               {'주문 상태: '}
               <Chip
                 size="small"
-                label={renderOrderStatus(merchandiseOrder.status)}
-                color={merchandiseOrder.status === 주문상태_상품준비 ? 'primary' : 'default'}
+                label={merchandiseOrder.statusString}
+                color={[주문상태_상품준비, 주문상태_출고준비].includes(merchandiseOrder.status) ? 'primary' : 'default'}
                 className={classnames({
-                  [classes.success]: [주문상태_출고준비, 주문상태_출고완료].includes(merchandiseOrder.status),
+                  [classes.success]: [주문상태_배송완료, 주문상태_출고완료].includes(merchandiseOrder.status),
                 })}
               />
             </Typography>

--- a/client-ts/src/organisms/mypage/marketer/adManage/campaign/sub/OrderManageTabContents.tsx
+++ b/client-ts/src/organisms/mypage/marketer/adManage/campaign/sub/OrderManageTabContents.tsx
@@ -76,7 +76,7 @@ export default function OrderManageTabContents({
               field: 'status',
               width: 130,
               renderCell: (data): React.ReactElement => (
-                <Chip label={renderOrderStatus(data.row.status)} />
+                <Chip label={data.row.statusString} />
               )
             },
             { headerName: '수량', field: 'quantity', width: 130, },

--- a/client-ts/src/organisms/mypage/marketer/adManage/campaign/sub/OrderManageTabContents.tsx
+++ b/client-ts/src/organisms/mypage/marketer/adManage/campaign/sub/OrderManageTabContents.tsx
@@ -5,7 +5,6 @@ import React, { useState } from 'react';
 import CustomDataGrid from '../../../../../../atoms/Table/CustomDataGrid';
 // import CustomDataGrid from '../../../../../../atoms/Table/CustomDataGrid';
 import { useDialog, useGetRequest } from '../../../../../../utils/hooks';
-import renderOrderStatus from '../../../../../../utils/render_funcs/renderOrderStatus';
 import { CampaignInterface } from '../../../dashboard/interfaces';
 import { MerchandiseOrder } from '../../interface';
 import MerchandiseOrderDialog from './MerchandiseOrderDialog';

--- a/client-ts/src/organisms/mypage/marketer/adManage/interface.ts
+++ b/client-ts/src/organisms/mypage/marketer/adManage/interface.ts
@@ -94,6 +94,7 @@ export interface MerchandiseOrder {
   campaignId: string;
   optionId: number;
   status: number;
+  statusString: string;
   orderPrice: number;
   ordererName: string;
   recipientName: string;

--- a/client-ts/src/organisms/mypage/marketer/adManage/merchandise/MerchandiseInventory.tsx
+++ b/client-ts/src/organisms/mypage/marketer/adManage/merchandise/MerchandiseInventory.tsx
@@ -1,6 +1,6 @@
 import moment from 'moment';
 import {
-  IconButton, makeStyles, Typography
+  IconButton, makeStyles, Tooltip, Typography
 } from '@material-ui/core';
 import React, { useState } from 'react';
 import { Delete } from '@material-ui/icons';
@@ -10,6 +10,7 @@ import { Merchandise } from '../interface';
 import MerchandiseDeleteDialog from './MerchandiseDeleteDialog';
 import { useDialog } from '../../../../../utils/hooks';
 import Snackbar from '../../../../../atoms/Snackbar/Snackbar';
+import renderMerchandiseUploadState from '../../../../../utils/render_funcs/renderMerchandiseUploadState';
 
 const useStyles = makeStyles(() => ({
   datagrid: { height: 400, width: '100%' },
@@ -71,6 +72,23 @@ export default function MerchandiseInventory({
             field: 'stock',
             headerName: '재고',
             width: 150,
+          },
+          {
+            field: 'uploadState',
+            headerName: '상태',
+            width: 120,
+            renderCell: (data): React.ReactElement => (
+              <div>
+                <Typography variant="body2" noWrap>
+                  {renderMerchandiseUploadState(data.row.uploadState)}
+                </Typography>
+                {data.row.uploadState === 0 && data.row.denialReason && (
+                  <Tooltip title={`사유: ${data.row.denialReason}`}>
+                    <Typography noWrap variant="body2">{`사유: ${data.row.denialReason}`}</Typography>
+                  </Tooltip>
+                )}
+              </div>
+            )
           },
           {
             field: 'createDate',

--- a/client-ts/src/organisms/mypage/marketer/campaign-create2/CampaignFormComponents/SelectMerchandise.tsx
+++ b/client-ts/src/organisms/mypage/marketer/campaign-create2/CampaignFormComponents/SelectMerchandise.tsx
@@ -41,9 +41,17 @@ export default function SelectMerchandise({
       <StyledItemText
         primary="판매 상품 선택하기"
         secondary={(
-          <Typography variant="body2" color="textSecondary">
-            선택된 상품은 온애드몰에서 판매됩니다.
-          </Typography>
+          <div>
+            <Typography variant="body2" color="textSecondary">
+              선택된 상품은 온애드몰에서 판매됩니다.
+            </Typography>
+            <Typography variant="body2" color="textSecondary">
+              다른 캠페인에 연결되지 않은 상품만 표시됩니다.
+              <Typography component="span" color="error" variant="body2">
+                {' (상품은 1개의 캠페인에만 연결될 수 있습니다.)'}
+              </Typography>
+            </Typography>
+          </div>
         )}
         // className={classes.label}
       />

--- a/client-ts/src/organisms/mypage/marketer/campaign-create2/CampaignFormPaper.tsx
+++ b/client-ts/src/organisms/mypage/marketer/campaign-create2/CampaignFormPaper.tsx
@@ -70,7 +70,7 @@ function CampaignFormPaper({
 
   const landingUrlData = useGetRequest('/marketer/landing-url/list');
   const bannerData = useGetRequest('/marketer/banner/list/active');
-  const merchandiseData = useGetRequest('/marketer/merchandises');
+  const merchandiseData = useGetRequest('/marketer/merchandises', { onlyNotConnected: true });
 
   const bannerUploadDialog = useDialog();
   const landingUrlUploadDialog = useDialog();

--- a/client-ts/src/organisms/mypage/marketer/dashboard/interfaces.ts
+++ b/client-ts/src/organisms/mypage/marketer/dashboard/interfaces.ts
@@ -42,6 +42,7 @@ export interface CampaignInterface {
   merchandiseSoldCount?: number;
   merchandiseItemSiteUrl?: string;
   merchandiseUploadState?: number;
+  merchandiseDenialReason?: string;
 }
 
 export interface OnOffInterface {

--- a/client-ts/src/organisms/mypage/marketer/shared/MerchandiseUploadDialog.tsx
+++ b/client-ts/src/organisms/mypage/marketer/shared/MerchandiseUploadDialog.tsx
@@ -19,7 +19,7 @@ import AddressInput, { OnadAddressData } from './sub/MerchandiseAddressInput';
 import MerchandiseImageUpload from './sub/MerchandiseImageUpload';
 import MerchandiseOptionInput from './sub/MerchandiseOptionInput';
 import MerchandiseUploadDialogLoading from './sub/MerchandiseUploadDialogLoading';
-import { getS3MerchandiseImagePath } from '../../../../utils/aws/getS3Path';
+import { getS3MerchandiseImagePath, getS3MerchandiseDescImagePath } from '../../../../utils/aws/getS3Path';
 
 const FLAG_ON = 'Yes';
 const FLAG_OFF = 'No';
@@ -197,7 +197,7 @@ export default function MerchandiseUploadDialog({
         handleLoadingStatus('상품 사진 등록 중...');
         const { id: uploadedMerchandiseId, marketerId } = data;
         // 상품 사진 S3 업로드
-        const key = `merchandises/${marketerId}/${uploadedMerchandiseId}/merchandise`;
+        const key = getS3MerchandiseImagePath(marketerId, uploadedMerchandiseId);
         const uploadFailCallback = (err: any) => {
           formLoading.handleClose();
           if (onFail) onFail();
@@ -205,7 +205,7 @@ export default function MerchandiseUploadDialog({
           console.error(err);
         };
         const uploadSuccessCallback = () => {
-          const descImagesKey = getS3MerchandiseImagePath(marketerId, uploadedMerchandiseId);
+          const descImagesKey = getS3MerchandiseDescImagePath(marketerId, uploadedMerchandiseId);
           // 상품 설명 이미지 업로드
           descImages.uploadToS3(
             descImagesKey,

--- a/client-ts/src/utils/aws/getS3Path.ts
+++ b/client-ts/src/utils/aws/getS3Path.ts
@@ -16,3 +16,16 @@ export function getS3MerchandiseImagePath(
     fileName || ''
   );
 }
+
+export function getS3MerchandiseDescImagePath(
+  marketerId: string, merchandiseId: string, fileName?: string
+): string {
+  return path.join(
+    S3_BASE_URL,
+    'merchandises',
+    marketerId,
+    merchandiseId,
+    'desc-images',
+    fileName || ''
+  );
+}

--- a/client-ts/src/utils/render_funcs/renderMerchandiseUploadState.ts
+++ b/client-ts/src/utils/render_funcs/renderMerchandiseUploadState.ts
@@ -1,8 +1,11 @@
 
-export const MERCHANDISE_UPLOADED = 1; // 온애드몰 업로드된 경우
-export const MERCHANDISE_SOLDOUT = 2; // 온애드몰 업로드 이후 완판 또는 모종의 이유로 온애드몰 목록에서 다시 내려간 경우
+export const MERCHANDISE_UPLOAD_WAITING = null; // 온애드몰 업로드 대기중 상태
+export const MERCHANDISE_UPLOAD_DENYED = 0; // 온애드몰 업로드 거절된 경우
+export const MERCHANDISE_UPLOAD_UPLOADED = 1; // 온애드몰 업로드된 경우
+export const MERCHANDISE_UPLOAD_SOLDOUT = 2; // 온애드몰 업로드 이후 완판 또는 모종의 이유로 온애드몰 목록에서 다시 내려간 경우
 
-export default function renderMerchandiseUploadState(state: number): string {
-  const lookupArray = ['준비중', '판매중', '판매완료'];
+export default function renderMerchandiseUploadState(state: number | null): string {
+  const lookupArray = ['판매거절됨', '판매중', '판매완료'];
+  if (state === null) return '준비중';
   return lookupArray[state];
 }

--- a/client-ts/src/utils/render_funcs/renderOrderStatus.ts
+++ b/client-ts/src/utils/render_funcs/renderOrderStatus.ts
@@ -1,14 +1,18 @@
-// 주문상태(0=주문접수,1=결제확인,2=상품준비,3=출고준비,4=출고완료,5=배송중,6=배송완료,7=반품요청,8=구매완료대기,9=구매완료)
+// 주문상태(0=주문접수,1=상품준비중,2=출고준비, 3=출고완료,4=배송완료, 5=주문취소)
 
 export const 주문상태_주문접수 = 0;
-export const 주문상태_상품준비중 = 1;
-export const 주문상태_출고준비완료 = 2;
-export const 주문상태_주문취소 = 3;
+export const 주문상태_상품준비 = 1;
+export const 주문상태_출고준비 = 2;
+export const 주문상태_출고완료 = 3;
+export const 주문상태_배송완료 = 4;
+export const 주문상태_주문취소 = 5;
 
 export const orderStatus = [
   '주문접수',
-  '상품준비중',
-  '출고준비완료',
+  '상품준비',
+  '출고준비',
+  '출고완료',
+  '배송완료',
   '주문취소',
 ];
 export default function renderOrderStatus(status: number): string {

--- a/client-ts/src/utils/render_funcs/renderOrderStatus.ts
+++ b/client-ts/src/utils/render_funcs/renderOrderStatus.ts
@@ -6,6 +6,7 @@ export const 주문상태_출고준비 = 2;
 export const 주문상태_출고완료 = 3;
 export const 주문상태_배송완료 = 4;
 export const 주문상태_주문취소 = 5;
+export const 주문상태_구매확정 = 6;
 
 export const orderStatus = [
   '주문접수',
@@ -14,6 +15,7 @@ export const orderStatus = [
   '출고완료',
   '배송완료',
   '주문취소',
+  '구매확정',
 ];
 export default function renderOrderStatus(status: number): string {
   return orderStatus[status];

--- a/server/routes/creator/banner/index.ts
+++ b/server/routes/creator/banner/index.ts
@@ -373,10 +373,10 @@ router.route('/active')
         JOIN campaign AS cp ON ct.campaignId = cp.campaignId
         JOIN marketerInfo AS mi ON cp.marketerId = mi.marketerId
         JOIN bannerRegistered AS br  ON cp.bannerId = br.bannerId
-        JOIN linkRegistered AS lr ON cp.connectedLinkId = lr.linkId
+        LEFT JOIN linkRegistered AS lr ON cp.connectedLinkId = lr.linkId
       WHERE creatorId = ?
         AND ct.date > DATE_ADD(NOW(), INTERVAL - 10 MINUTE) 
-      ORDER BY ct.date DESC LIMIT 1       
+      ORDER BY ct.date DESC LIMIT 1
       `;
 
       doQuery(query, [creatorId])

--- a/server/routes/creator/clicks/index.ts
+++ b/server/routes/creator/clicks/index.ts
@@ -47,7 +47,7 @@ router.route('/current')
       const query = `
       SELECT tracking.id, clickedTime, costType, tracking.linkId, campaignName, links, creatorId, payout, channel, os, browser
         FROM tracking
-        JOIN linkRegistered AS lr
+        LEFT JOIN linkRegistered AS lr
         ON lr.linkId = tracking.linkId
         WHERE creatorId = ?
         ORDER BY clickedTime DESC

--- a/server/routes/marketer/campaign/index.ts
+++ b/server/routes/marketer/campaign/index.ts
@@ -72,7 +72,7 @@ router.route('/list')
         campaignDescription, startDate, finDate, selectedTime, targetList, campaign.merchandiseId,
         mr.name AS merchandiseName, mr.stock AS merchandiseStock,
         mm.soldCount AS merchandiseSoldCount, mm.itemSiteUrl AS merchandiseItemSiteUrl,
-        mm.uploadState AS merchandiseUploadState
+        mm.uploadState AS merchandiseUploadState, mm.denialReason AS merchandiseDenialReason
       FROM campaign
         JOIN bannerRegistered AS br ON br.bannerId = campaign.bannerId
         LEFT JOIN linkRegistered AS lr ON lr.linkId = connectedLinkId

--- a/server/routes/marketer/inventory/merchandises.ts
+++ b/server/routes/marketer/inventory/merchandises.ts
@@ -147,9 +147,11 @@ const findWithPagination = async (
   marketerId: string, page: number, offset: number
 ): Promise<Merchandise[]> => {
   const query = `
-    SELECT *
-    FROM merchandiseRegistered WHERE marketerId = ?
-    ORDER BY createDate DESC
+    SELECT mr.*, mmi.uploadState, denialReason
+    FROM merchandiseRegistered AS mr
+    LEFT JOIN merchandiseMallItems AS mmi ON mmi.merchandiseId = mr.id
+    WHERE marketerId = ?
+    ORDER BY createDate DESC                   
     LIMIT ?, ?
   `;
 

--- a/server/routes/marketer/orders/index.ts
+++ b/server/routes/marketer/orders/index.ts
@@ -26,11 +26,12 @@ router.route('/')
 
       const query = `
       SELECT
-        mo.id, mo.merchandiseId, campaignId, optionId, status, orderPrice, ordererName, recipientName, quantity, mo.createDate,
+        mo.id, mo.merchandiseId, campaignId, optionId, status, statusString, orderPrice, ordererName, recipientName, quantity, mo.createDate,
         mr.name, mr.price, stock, optionFlag, mopt.type as optionType, mopt.name as optionValue, mopt.additionalPrice,
         mm.soldCount AS merchandiseSoldCount
       FROM merchandiseOrders AS mo
       JOIN merchandiseRegistered AS mr ON mr.id =  mo.merchandiseId
+      JOIN merchandiseOrderStatuses AS mos ON mo.status = mos.statusNumber
       LEFT JOIN merchandiseOptions AS mopt ON mo.optionId = mopt.id
       LEFT JOIN merchandiseMallItems AS mm ON mr.id = mm.merchandiseId
        `;

--- a/socket/public/callImg.ts
+++ b/socket/public/callImg.ts
@@ -284,6 +284,21 @@ function callImg(socket: Socket, msg: string[]): void {
     });
   };
 
+  /**
+   * 해당 캠페인에 연결된 상품의 온애드몰 URL을 가져옵니다.
+   * @param campaignId 캠페인 아이디
+   * @returns 상품 사이트 URL 문자열
+   */
+  const getMerchandiseSiteUrl = async (campaignId: string): Promise<string> => {
+    const query = `SELECT itemSiteUrl
+    FROM merchandiseMallItems
+    JOIN campaign on campaign.merchandiseId = merchandiseMallItems.merchandiseId
+    WHERE campaignId = ?`;
+    const { result } = await doQuery(query, [campaignId]);
+    if (!(result.length > 0)) return '';
+    return result[0].itemSiteUrl;
+  };
+
   const getRandomInt = (length: number): number => {
     const max = Math.floor(length);
     return Math.floor(Math.random() * (max - 0)) + 0; // 최댓값은 제외, 최솟값은 포함
@@ -304,20 +319,21 @@ function callImg(socket: Socket, msg: string[]): void {
     // *********************************************************
     // 크리에이터 개인에게 할당된(크리에이터 에게 송출) 캠페인 -> ON 상태 필터링
     const onCreatorcampaignList = creatorCampaignList.filter(
-      (campaignId) => onCampaignList.includes(campaignId)
+      (campaignId: any) => onCampaignList.includes(campaignId)
     );
 
     // 현재 ON상태인 크리에이터 개인에게 할당된(크리에이터 에게 송출) 캠페인 목록이 있는 경우
     if (onCreatorcampaignList.length !== 0) {
       const extractPausedCampaignList = onCreatorcampaignList
-        .filter((campaignId) => !checkList.pausedList.includes(campaignId)); // 일시정지 배너 거르기.
+        .filter((campaignId: any) => !checkList.pausedList.includes(campaignId)); // 일시정지 배너 거르기.
       const extractBanCampaignList = extractPausedCampaignList
-        .filter((campaignId) => !checkList.banList.includes(campaignId)); // 마지막에 banList를 통해 거르기.
+        .filter((campaignId: any) => !checkList.banList.includes(campaignId)); // 마지막에 banList를 통해 거르기.
       if (extractBanCampaignList) {
         const returnCampaignId = extractBanCampaignList[
           getRandomInt(extractBanCampaignList.length)
         ];
         myCampaignId = returnCampaignId;
+        console.log('캠페인 : ', myCampaignId);
       }
     } else {
       // *********************************************************
@@ -336,10 +352,16 @@ function callImg(socket: Socket, msg: string[]): void {
 
     // *********************************************************
     // RETRUN 섹션
-    if (myCampaignId && campaignObject[myCampaignId][0] === 1) {
+    const OPTION_TYPE_LIVE_BANNER_CAMPAIGN = 1; // 생방송 라이브 배너광고 캠페인의 경우
+    const OPTION_TYPE_CPS_CAMPAIGN = 3; // 판매형광고(CPS) 캠페인의 경우
+
+    if (myCampaignId && campaignObject[myCampaignId][0] === OPTION_TYPE_LIVE_BANNER_CAMPAIGN) {
       // 송출될 캠페인의 link 를 가져와 트위치 챗봇에 챗봇광고 이벤트를 에밋하기 위한 정보를 가져온다.
       console.log(`${creatorId} / 광고될 캠페인은 ${myCampaignId} / ${getTime}`);
       linkToChatBot = await getLinkName(myCampaignId);
+    } else if (myCampaignId && campaignObject[myCampaignId][0] === OPTION_TYPE_CPS_CAMPAIGN) {
+      console.log(`${creatorId} / 광고될 캠페인은 ${myCampaignId} / ${getTime}`);
+      linkToChatBot = await getMerchandiseSiteUrl(myCampaignId);
     } else {
       // 송출할 광고 없다.
       // 기본배너 검색

--- a/tracker/lib/queries/createInformationQuery.ts
+++ b/tracker/lib/queries/createInformationQuery.ts
@@ -10,12 +10,13 @@ export default function createInformationQuery(
   if (broadPlatform === 'afreeca') {
     const getInformationQuery = `
     SELECT
-        campaign.campaignId, campaign.campaignName, creatorInfo.creatorId, campaign.marketerId,
-        campaignTimestamp.date, connectedLinkId, links, creatorName
+      campaign.optionType, campaign.campaignId, campaign.campaignName, creatorInfo.creatorId, campaign.marketerId,
+        campaignTimestamp.date, connectedLinkId, links, creatorName, campaign.merchandiseId, itemSiteUrl
       FROM campaignTimestamp
         JOIN creatorInfo ON afreecaId = ?
         JOIN campaign ON campaign.campaignId = campaignTimestamp.campaignId
-        JOIN linkRegistered ON linkRegistered.linkId = connectedLinkId
+        LEFT JOIN linkRegistered ON linkRegistered.linkId = connectedLinkId
+        LEFT JOIN merchandiseMallItems ON campaign.merchandiseId = merchandiseMallItems.merchandiseId
         JOIN AfreecaBroad ON creatorInfo.afreecaId = AfreecaBroad.userId
         JOIN AfreecaBroadDetail on AfreecaBroad.broadId = AfreecaBroadDetail.broadId
       WHERE campaignTimestamp.creatorId = creatorInfo.creatorId
@@ -28,12 +29,13 @@ export default function createInformationQuery(
 
   const getInformationQuery = `
       SELECT
-        campaign.campaignId, campaign.campaignName, creatorInfo.creatorId, campaign.marketerId,
-        campaignTimestamp.date, connectedLinkId, links, creatorName
+      campaign.optionType, campaign.campaignId, campaign.campaignName, creatorInfo.creatorId, campaign.marketerId,
+        campaignTimestamp.date, connectedLinkId, links, creatorName, campaign.merchandiseId, itemSiteUrl
       FROM campaignTimestamp
         JOIN creatorInfo ON creatorTwitchId = ?
         JOIN campaign ON campaign.campaignId = campaignTimestamp.campaignId
-        JOIN linkRegistered ON linkRegistered.linkId = connectedLinkId
+        LEFT JOIN linkRegistered ON linkRegistered.linkId = connectedLinkId
+        LEFT JOIN merchandiseMallItems ON campaign.merchandiseId = merchandiseMallItems.merchandiseId
         JOIN twitchStreamDetail ON creatorInfo.creatorName = twitchStreamDetail.streamerName
       WHERE campaignTimestamp.creatorId = creatorInfo.creatorId
         AND campaignTimestamp.date > date_sub(NOW(), INTERVAL 10 MINUTE)

--- a/tracker/lib/queries/createTrackingInsertQuery.ts
+++ b/tracker/lib/queries/createTrackingInsertQuery.ts
@@ -1,8 +1,8 @@
 
 export interface TrackingInsertParams {
-    costType: 'CPC' | 'CPA';
+    costType: 'CPC' | 'CPA' | 'CPS';
     conversinoTime: Date | null;
-    connectedLinkId: string;
+    connectedLinkId: string | null;
     campaignId: string;
     campaignName: string;
     marketerId: string;

--- a/tracker/lib/trackingLogging.ts
+++ b/tracker/lib/trackingLogging.ts
@@ -1,5 +1,5 @@
 export default function trackingLogging(
-  channelType: string, creatorId: string, message: string
+  channelType: string, creatorId: string, message: string,
 ): void{
   console.log(`[${new Date().toLocaleString()}] ${channelType}|${creatorId} - ${message}`);
 }


### PR DESCRIPTION
#519 병합 이후 진행

- 클릭 배너 추적 로직
    - [x]  캠페인 정보 조회시 merchandiseId, itemSiteUrl 추가
    - [x]  CPS 캠페인 분기처리
        - [x]  tracking DB 입력 처리
        - [x]  CPS 타입 명시
- 배너 송출

    라이브배너광고인 경우에만 배너 송출이 되도록 설정되어 있어 배너 송출이 불가하였음. 이를 처리.

    - [x]  CPS 광고일 경우의 분기 처리 추가
    - [x]  CPS 광고 캠페인에 연결된 상품의 온애드몰사이트URL 찾기함수 추가
    - [x]  CPS 광고 캠페인 챗봇광고 링크 온애드몰사이트URL로 변경