### PR TITLE
라이브커머스 이벤트 팝업 핫픽스

### DIFF
--- a/client-ts/src/organisms/shared/popup/CPSEventDialog.tsx
+++ b/client-ts/src/organisms/shared/popup/CPSEventDialog.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import EventPopup from '../../../atoms/Dialog/EventPopup';
 
 export interface RenewalDialogProps {
@@ -19,13 +19,19 @@ export default function RenewalDialog({
       disableFullWidth
       noShowKey="cps-event-popup-no-show"
     >
-      <img draggable={false} src="/pngs/main-popup/cps_full.png" alt="" height={600} width="100%" />
+      <img
+        draggable={false}
+        src="/pngs/main-popup/cps_full.png"
+        alt=""
+        height={600}
+        width="100%"
+      />
       <button
         type="button"
         style={{
           position: 'absolute',
           backgroundColor: 'tan',
-          bottom: 60,
+          top: 518,
           left: 130,
           height: 65,
           width: 185,
@@ -33,7 +39,7 @@ export default function RenewalDialog({
           cursor: 'pointer',
         }}
         onClick={(): void => {
-          window.open(GOOGLE_FORM_URL);
+          window.open(GOOGLE_FORM_URL, '_blank');
         }}
       >
         참여하기

--- a/client-ts/src/organisms/shared/popup/CPSEventDialog.tsx
+++ b/client-ts/src/organisms/shared/popup/CPSEventDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React from 'react';
 import EventPopup from '../../../atoms/Dialog/EventPopup';
 
 export interface RenewalDialogProps {


### PR DESCRIPTION
팝업의 투명 래핑 버튼 위치 기준을 아래에서 잡지 않고 위에서 잡아, 스크롤이 생겼을 때 버튼위치와 이미지상의 버튼위치가 어긋나는 문제 해결