### PR TITLE
Fix: finDate datestring 형태 -> Date객체

### DIFF
--- a/server/routes/marketer/campaign/index.ts
+++ b/server/routes/marketer/campaign/index.ts
@@ -252,7 +252,9 @@ router.route('/')
                 // @by hwasurr "1-1" 은 아프리카 카테고리 선택형. 1로 수정하여 카테고리 선택형으로 넣는다.
                 (priorityType === '1-1') ? '1' : priorityType,
                 optionType, targetJsonData, marketerName, keywordsJsonData,
-                new Date(startDate), finDate, timeJsonData, campaignDescription, merchandiseId || null]),
+                new Date(startDate),
+                finDate ? new Date(finDate) : finDate,
+                timeJsonData, campaignDescription, merchandiseId || null]),
             dataProcessing.PriorityDoquery({
               campaignId,
               priorityType,


### PR DESCRIPTION
DB 버전 업데이트로 인한 변경사항 중 하나인 것 같음.

기존 에는 '2021-04-30T09:02:00.000Z' 형식의 데이터를 보낼 때 올바르게 처리되었으나
이제는 타입이 안맞다고 에러를 뱉음.

캠페인의 finDate를 문자열이 아닌 Date 객체로 넘기는 방식으로 변경

ER_TRUNCATED_WRONG_VALUE: Incorrect datetime value: '2021-04-30T09:02:00.000Z' for column `onadnode`.`campaign`.`finDate` at row 1