### PR TITLE
라이브커머스 계산 추가

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,7 +3,6 @@
     "plugins": [
         "react",
         "prettier",
-        "jest",
         "react-hooks"
     ],
     "extends": [
@@ -122,5 +121,5 @@
         "browser": true,
         "jest": true,
         "es6": true
-        }
     }
+}

--- a/.github/workflows/pr-check-master.yml
+++ b/.github/workflows/pr-check-master.yml
@@ -15,34 +15,45 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Cache yarn dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
-          path: node_modules
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
+
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
+
+      - name: <client-ts> install dependencies
+        working-directory: ./client-ts
+        if: steps.yarn-cache.outputs.cache-hit != 'true'
+        run: yarn intsall
+
       - name: <client-ts> test/build-test/
-        run: |
-          cd client-ts
-          yarn
-          yarn test --watchAll=false
-          cd -
+        working-directory: ./client-ts
+        run: yarn test --watchAll=false
+
+      - name: <server> install dependencies
+        working-directory: ./server
+        if: steps.yarn-cache.outputs.cache-hit != 'true'
+        run: yarn intsall
+
       - name: <server> test/build-test/
-        run: |
-          cd server
-          yarn
-          yarn test --watchAll=false
-          cd -
+        working-directory: ./server
+        run: yarn test --watchAll=false
+
+      - name: <calculator> install dependencies
+        working-directory: ./calculator
+        if: steps.yarn-cache.outputs.cache-hit != 'true'
+        run: yarn intsall
+
       - name: <calculator> test
-        run: |
-          cd calculator
-          yarn
-          yarn test
+        working-directory: ./calculator
+        run: yarn test
 
   build:
     strategy:
@@ -69,16 +80,20 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      - name: <client-ts> install dependencies
+        working-directory: ./client-ts
+        if: steps.yarn-cache.outputs.cache-hit != 'true'
+        run: yarn install
+
       - name: <client-ts> test/build-test/
-        run: |
-          cd client-ts
-          yarn
-          yarn build
-          cd -
+        working-directory: ./client-ts
+        run: yarn build
+
+      - name: <server> install dependencies
+        working-directory: ./server
+        if: steps.yarn-cache.outputs.cache-hit != 'true'
+        run: yarn install
 
       - name: <server> test/build-test/
-        run: |
-          cd server
-          yarn
-          yarn build
-          cd -
+        working-directory: ./server
+        run: yarn build

--- a/.github/workflows/pr-check-master.yml
+++ b/.github/workflows/pr-check-master.yml
@@ -35,7 +35,7 @@ jobs:
       - name: <client-ts> install dependencies
         working-directory: ./client-ts
         if: steps.yarn-cache.outputs.cache-hit != 'true'
-        run: yarn intsall
+        run: yarn install
 
       - name: <client-ts> test/build-test/
         working-directory: ./client-ts
@@ -44,7 +44,7 @@ jobs:
       - name: <server> install dependencies
         working-directory: ./server
         if: steps.yarn-cache.outputs.cache-hit != 'true'
-        run: yarn intsall
+        run: yarn install
 
       - name: <server> test/build-test/
         working-directory: ./server
@@ -53,7 +53,7 @@ jobs:
       - name: <calculator> install dependencies
         working-directory: ./calculator
         if: steps.yarn-cache.outputs.cache-hit != 'true'
-        run: yarn intsall
+        run: yarn install
 
       - name: <calculator> test
         working-directory: ./calculator

--- a/.github/workflows/pr-check-master.yml
+++ b/.github/workflows/pr-check-master.yml
@@ -5,13 +5,50 @@ on:
     branches: [master]
 
 jobs:
+  test:
+    strategy:
+      matrix:
+        node-version: [12.x]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v2
+
+      - name: Cache yarn dependencies
+        uses: actions/cache@v1
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: <client-ts> test/build-test/
+        run: |
+          cd client-ts
+          yarn
+          yarn test --watchAll=false
+          cd -
+      - name: <server> test/build-test/
+        run: |
+          cd server
+          yarn
+          yarn test --watchAll=false
+          cd -
+      - name: <calculator> test
+        run: |
+          cd calculator
+          yarn
+          yarn test
+
   build:
     strategy:
       matrix:
         node-version: [12.x]
-
     runs-on: ubuntu-latest
-
     # This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
     # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
     steps:
@@ -36,7 +73,6 @@ jobs:
         run: |
           cd client-ts
           yarn
-          yarn test --watchAll=false
           yarn build
           cd -
 
@@ -44,12 +80,5 @@ jobs:
         run: |
           cd server
           yarn
-          yarn test --watchAll=false
           yarn build
           cd -
-
-      - name: <calculator> test
-        run: |
-          cd calculator
-          yarn
-          yarn test

--- a/.github/workflows/pr-check-master.yml
+++ b/.github/workflows/pr-check-master.yml
@@ -14,6 +14,10 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v2
 
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
       - name: Cache yarn dependencies
         uses: actions/cache@v2
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
@@ -66,11 +70,15 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v2
 
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
       - name: Cache yarn dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
-          path: node_modules
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-

--- a/.github/workflows/pr-check-master.yml
+++ b/.github/workflows/pr-check-master.yml
@@ -47,3 +47,9 @@ jobs:
           yarn test --watchAll=false
           yarn build
           cd -
+
+      - name: <calculator> test
+        run: |
+          cd calculator
+          yarn
+          yarn test

--- a/calculator/__tests__/commission.js
+++ b/calculator/__tests__/commission.js
@@ -1,0 +1,45 @@
+const { getCashesCalculatedForLiveCommerce, getCashesCalculated } = require('../utils/cps/commission');
+
+describe('commission', () => {
+  test('[getCashesCalculatedForLiveCommerce] 10000 price, 0.3commission to creator, 0commission to onad', () => {
+    const param = {
+      orderPrice: 10000, creatorCommission: 0.3, onadCommission: 0
+    };
+    const {
+      cashToCreator, salesIncomeToMarketer
+    } = getCashesCalculatedForLiveCommerce(param);
+
+    expect(cashToCreator).toBe(3000);
+    expect(salesIncomeToMarketer).toBe(7000);
+  });
+
+  test('[getCashesCalculated] when creator is exists', () => {
+    const param = {
+      totalOrderPrice: 10000,
+      isCreatorExists: true,
+      creatorCommission: 0.1,
+      onadCommission: 0.1,
+    };
+    const {
+      cashToCreator, salesIncomeToMarketer
+    } = getCashesCalculated(param);
+
+    expect(cashToCreator).toBe(1000);
+    expect(salesIncomeToMarketer).toBe(8000);
+  });
+
+  test('[getCashesCalculated] when creator is not exists', () => {
+    const param = {
+      totalOrderPrice: 10000,
+      isCreatorExists: false,
+      creatorCommission: 0.1,
+      onadCommission: 0.1,
+    };
+    const {
+      cashToCreator, salesIncomeToMarketer
+    } = getCashesCalculated(param);
+
+    expect(cashToCreator).toBe(0);
+    expect(salesIncomeToMarketer).toBe(9000);
+  });
+});

--- a/calculator/__tests__/queries.test.js
+++ b/calculator/__tests__/queries.test.js
@@ -1,0 +1,103 @@
+const {
+  getCalculateCreatorIncome,
+  getCalculateMarketerSalesIncome,
+  getInsertCampaignLog,
+  getUpdateFlag,
+} = require('../utils/cps/queries');
+
+
+describe('queries', () => {
+  test('getCalculateCreatorIncome', () => {
+    const param = {
+      creatorId: '130096343',
+      cashToCreator: 1000,
+    };
+    const queryUnit = getCalculateCreatorIncome(param);
+    expect(queryUnit.query).toMatch(`
+    INSERT INTO creatorIncome (creatorId, creatorTotalIncome, creatorReceivable)
+    SELECT
+      creatorId,
+      IFNULL(MAX(creatorTotalIncome), 0) + ? AS creatorTotalIncome,
+      IFNULL(MAX(creatorReceivable), 0) + ? AS creatorReceivable
+    FROM creatorIncome AS a WHERE creatorId = ? ORDER BY date DESC LIMIT 1
+    `);
+
+    expect(queryUnit.queryArray[0]).toBe(1000);
+    expect(queryUnit.queryArray[1]).toBe(1000);
+    expect(queryUnit.queryArray[2]).toBe('130096343');
+  });
+
+  test('getCalculateMarketerSalesIncome', () => {
+    const param = {
+      marketerId: 'gubgoo',
+      salesIncomeToMarketer: 10000,
+      deliveryFee: 3000,
+    };
+    const queryUnit = getCalculateMarketerSalesIncome(param);
+
+    expect(queryUnit.query).toMatch(`
+    INSERT INTO marketerSalesIncome (marketerId, totalIncome, receivable, totalDeliveryFee, receivableDeliveryFee) 
+    SELECT
+      marketerId,
+      IFNULL(MAX(totalIncome), 0) + ? AS totalIncome,
+      IFNULL(MAX(receivable), 0) + ? AS receivable,
+      IFNULL(MAX(totalDeliveryFee), 0) + ? AS totalDeliveryFee,
+      IFNULL(MAX(receivableDeliveryFee), 0) + ? AS receivableDeliveryFee
+    FROM marketerSalesIncome AS a WHERE marketerId = ? ORDER BY createDate DESC LIMIT 1`);
+
+    expect(queryUnit.queryArray[0]).toBe(10000);
+    expect(queryUnit.queryArray[1]).toBe(10000);
+    expect(queryUnit.queryArray[2]).toBe(3000);
+    expect(queryUnit.queryArray[3]).toBe(3000);
+    expect(queryUnit.queryArray[4]).toBe('gubgoo');
+  });
+
+  test('getInsertCampaignLog when creatorId is exists', () => {
+    const param = {
+      campaignId: 'gubgoo_c42', creatorId: '130096343', cashToCreator: 1000, salesIncomeToMarketer: 4000
+    };
+
+    const queryUnit = getInsertCampaignLog(param);
+    expect(queryUnit.query).toMatch(`
+    INSERT INTO campaignLog
+    (campaignId, creatorId, type, cashToCreator, salesIncomeToMarketer)
+    VALUES (?, ?, ?, ?, ?)
+  `);
+
+    expect(queryUnit.queryArray[0]).toBe('gubgoo_c42');
+    expect(queryUnit.queryArray[1]).toBe('130096343');
+    expect(queryUnit.queryArray[2]).toBe('CPS');
+    expect(queryUnit.queryArray[3]).toBe(1000);
+    expect(queryUnit.queryArray[4]).toBe(4000);
+  });
+
+  test('getInsertCampaignLog when creatorId is not exists', () => {
+    const param = {
+      campaignId: 'gubgoo_c42', cashToCreator: 1000, salesIncomeToMarketer: 4000
+    };
+
+    const queryUnit = getInsertCampaignLog(param);
+    expect(queryUnit.query).toMatch(`
+    INSERT INTO campaignLog
+    (campaignId, creatorId, type, cashToCreator, salesIncomeToMarketer)
+    VALUES (?, ?, ?, ?, ?)
+  `);
+
+    expect(queryUnit.queryArray[0]).toBe('gubgoo_c42');
+    expect(queryUnit.queryArray[1]).toBe('');
+    expect(queryUnit.queryArray[2]).toBe('CPS');
+    expect(queryUnit.queryArray[3]).toBe(1000);
+    expect(queryUnit.queryArray[4]).toBe(4000);
+  });
+
+  test('getUpdateFlag', () => {
+    const param = {
+      orderId: 32
+    };
+    const queryUnit = getUpdateFlag(param);
+    expect(queryUnit.query).toMatch('UPDATE merchandiseOrders SET calculateDoneFlag = ? WHERE id = ?');
+
+    expect(queryUnit.queryArray[0]).toBe(1);
+    expect(queryUnit.queryArray[1]).toBe(32);
+  });
+});

--- a/calculator/app.js
+++ b/calculator/app.js
@@ -8,6 +8,8 @@ require('./javascripts/calculation_v.5')()
   .then(require('./javascripts/referralCodeCalculator'))
   // CPS 계산
   .then(require('./javascripts/cpsCalculator'))
+  // 라이브커머스 계산
+  .then(require('./javascripts/liveCommerceCalc'))
   .then(() => {
     process.exit(0);
   });

--- a/calculator/javascripts/cpsCalculator.js
+++ b/calculator/javascripts/cpsCalculator.js
@@ -78,7 +78,7 @@ const calculate = async ({
   creatorCommission, onadCommission,
 }) => {
   const { cashToCreator, salesIncomeToMarketer } = getCashesCalculated({
-    orderPrice,
+    totalOrderPrice: orderPrice,
     isCreatorExists: !!targetCreatorId,
     creatorCommission,
     onadCommission,
@@ -116,8 +116,8 @@ const calculate = async ({
     conn.commit();
     console.log(`[${new Date().toLocaleString()}] ${campaignId} 캠페인 (상품: ${name}, 방송인: ${creatorName || '없음'}) 계산 완료`);
   } catch (e) {
-    console.log(`[${new Date().toLocaleString()}] order: ${orderId}, marketer: ${marketerId} error occurred during calculate - `, e);
     conn.rollback();
+    throw e;
   } finally {
     conn.release();
   }

--- a/calculator/javascripts/cpsCalculator.js
+++ b/calculator/javascripts/cpsCalculator.js
@@ -4,33 +4,7 @@ const pool = require('../model/connectionPool');
 const {
   getUpdateFlag, getInsertCampaignLog, getCalculateCreatorIncome, getCalculateMarketerSalesIncome
 } = require('../utils/cps/queries');
-
-/**
-   * 각 유저별 계산 대금을 구합니다. 리뷰/자랑하기/응원하기 글의 대상인 방송인이 있는 지 여부를 기준으로
-   * 계산 대금은 다르게 계산됩니다.
-   * @author hwasurr
-   * @param { number } orderPrice 계산이 필요한 판매 대금
-   * @param { boolean } isCreatorExists 리뷰/자랑하기/응원하기 글의 대상인 방송인이 있는지 여부
-   * 1. 방송인 A로부터 유입된 시청자가 구입 + 인증(리뷰or자랑하기)**글을 남기고** 구매완료 시
-   *    - **⇒ 광고주 70 %, 방송인 A 20 %, 온애드 10 %**
-   * 
-   * 2. 방송인 A로부터 유입된 시청자가 구입 + 인증(리뷰or자랑하기)**글을 남기지 않고** 구매완료 시
-   *    - **⇒ 광고주 90 %, 온애드 10 %**
-   */
-const getCashesCalculated = ({
-  totalOrderPrice, isCreatorExists, creatorCommission, onadCommission
-}) => {
-  if (isCreatorExists) { // 1 번의 경우
-    const cashToCreator = Math.round(totalOrderPrice * creatorCommission);
-    const cashToOnad = Math.round(totalOrderPrice * onadCommission);
-    const salesIncomeToMarketer = totalOrderPrice - cashToCreator - cashToOnad;
-    return { cashToCreator, salesIncomeToMarketer };
-  }
-  const cashToCreator = 0;
-  const cashToOnad = Math.round(totalOrderPrice * onadCommission);
-  const salesIncomeToMarketer = totalOrderPrice - cashToOnad;
-  return { cashToCreator, salesIncomeToMarketer };
-};
+const { getCashesCalculated } = require('../utils/cps/commission');
 
 /**
  * 주문 목록 중, 

--- a/calculator/javascripts/liveCommerceCalc.js
+++ b/calculator/javascripts/liveCommerceCalc.js
@@ -3,6 +3,7 @@ const { doQuery } = require('../model/doQuery');
 const {
   getUpdateFlag, getInsertCampaignLog, getCalculateCreatorIncome, getCalculateMarketerSalesIncome
 } = require('../utils/cps/queries');
+const { getCashesCalculatedForLiveCommerce } = require('../utils/cps/commission');
 
 const getTargets = async () => {
   const query = `
@@ -24,13 +25,6 @@ const getTargets = async () => {
     ...res,
     targetCreatorId: JSON.parse(res.targetList).targetList[0], // 라이브커머스는 언제나 1명. (2명이상일 시 무시)
   }));
-};
-
-const getCashesCalculatedForLiveCommerce = ({ orderPrice, creatorCommission, onadCommission }) => {
-  const cashToCreator = Math.round(orderPrice * creatorCommission);
-  const cashToOnad = Math.round(orderPrice * onadCommission);
-  const salesIncomeToMarketer = orderPrice - cashToCreator - cashToOnad;
-  return { cashToCreator, salesIncomeToMarketer };
 };
 
 const calculate = async ({
@@ -112,3 +106,4 @@ async function liveCommerceCalc() {
 }
 
 module.exports = liveCommerceCalc;
+exports.getCashesCalculatedForLiveCommerce = getCashesCalculatedForLiveCommerce;

--- a/calculator/javascripts/liveCommerceCalc.js
+++ b/calculator/javascripts/liveCommerceCalc.js
@@ -17,7 +17,7 @@ const getTargets = async () => {
    JOIN campaign ON campaign.campaignId = MO.campaignId
   WHERE statusString = ? AND calculateDoneFlag = ? AND isLiveCommerce = ?`;
 
-  const { result } = await doQuery(query, ['구매확정', 0, true])
+  const { result } = await doQuery(query, ['구매확정', false, true])
     .catch((err) => `error occurred during run getTargets - ${err}`);
 
   return result.map((res) => ({
@@ -74,8 +74,8 @@ const calculate = async ({
     connection.commit();
     console.log(`[${new Date().toLocaleString()}] ${campaignId} 캠페인 (상품: ${name}, 방송인: ${targetCreatorId}) 계산 완료`);
   } catch (e) {
-    console.log(`[order: ${orderId}, marketer: ${marketerId}]error occurred during calculate - `, e);
     connection.rollback();
+    throw e;
   } finally {
     connection.release();
   }

--- a/calculator/javascripts/liveCommerceCalc.js
+++ b/calculator/javascripts/liveCommerceCalc.js
@@ -91,8 +91,8 @@ const calculate = async ({
     orderPrice, creatorCommission, onadCommission
   });
 
-  connection.beginTransaction();
   try {
+    connection.beginTransaction();
     // * 1. 광고주 판매대금 처리 (marketerSalesIncome)
     const marketerSalesIncome = calculateMarketerSalesIncome({
       marketerId, salesIncomeToMarketer, deliveryFee
@@ -118,7 +118,7 @@ const calculate = async ({
     connection.commit();
     console.log(`[${new Date().toLocaleString()}] ${campaignId} 캠페인 (상품: ${name}, 방송인: ${targetCreatorId}) 계산 완료`);
   } catch (e) {
-    console.log(`[order${orderId}, marketer${marketerId}]error occurred during calculate - `, e);
+    console.log(`[order: ${orderId}, marketer: ${marketerId}]error occurred during calculate - `, e);
     connection.rollback();
   } finally {
     connection.release();

--- a/calculator/javascripts/liveCommerceCalc.js
+++ b/calculator/javascripts/liveCommerceCalc.js
@@ -1,0 +1,158 @@
+const pool = require('../model/connectionPool');
+const { doQuery } = require('../model/doQuery');
+
+const getTargets = async () => {
+  const query = `
+  SELECT
+    MO.id, MO.campaignId, MO.merchandiseId, orderPrice, calculateDoneFlag, deliveryFee,
+    MR.marketerId, MR.name, creatorCommission, onadCommission,
+    statusString,
+    campaign.targetList
+  FROM merchandiseOrders AS MO
+  JOIN merchandiseRegistered AS MR ON MR.id = MO.merchandiseId
+  JOIN merchandiseOrderStatuses AS MOS ON MOS.statusNumber = MO.status
+   JOIN campaign ON campaign.campaignId = MO.campaignId
+  WHERE statusString = ? AND calculateDoneFlag = ? AND isLiveCommerce = ?`;
+
+  const { result } = await doQuery(query, ['구매확정', 0, true])
+    .catch((err) => `error occurred during run getTargets - ${err}`);
+
+  return result.map((res) => ({
+    ...res,
+    targetCreatorId: JSON.parse(res.targetList).targetList[0], // 라이브커머스는 언제나 1명. (2명이상일 시 무시)
+  }));
+};
+
+const getCashesCalculated = ({ orderPrice, creatorCommission, onadCommission }) => {
+  const cashToCreator = Math.round(orderPrice * creatorCommission);
+  const cashToOnad = Math.round(orderPrice * onadCommission);
+  const salesIncomeToMarketer = orderPrice - cashToCreator - cashToOnad;
+  return { cashToCreator, salesIncomeToMarketer };
+};
+
+const calculateMarketerSalesIncome = ({ marketerId, salesIncomeToMarketer, deliveryFee }) => {
+  const query = `
+  INSERT INTO marketerSalesIncome (marketerId, totalIncome, receivable, totalDeliveryFee, receivableDeliveryFee) 
+  SELECT
+    marketerId,
+    IFNULL(MAX(totalIncome), 0) + ? AS totalIncome,
+    IFNULL(MAX(receivable), 0) + ? AS receivable,
+    IFNULL(MAX(totalDeliveryFee), 0) + ? AS totalDeliveryFee,
+    IFNULL(MAX(receivableDeliveryFee), 0) + ? AS receivableDeliveryFee
+  FROM marketerSalesIncome AS a WHERE marketerId = ? ORDER BY createDate DESC LIMIT 1`;
+  const queryArray = [
+    salesIncomeToMarketer, salesIncomeToMarketer, deliveryFee, deliveryFee, marketerId
+  ];
+  return { query, queryArray };
+};
+
+const calculateCreatorIncome = ({ creatorId, cashToCreator }) => {
+  const creatorIdStr = String(creatorId);
+  const query = `
+  INSERT INTO creatorIncome (creatorId, creatorTotalIncome, creatorReceivable)
+  SELECT
+    creatorId,
+    IFNULL(MAX(creatorTotalIncome), 0) + ? AS creatorTotalIncome,
+    IFNULL(MAX(creatorReceivable), 0) + ? AS creatorReceivable
+  FROM creatorIncome AS a WHERE creatorId = ? ORDER BY date DESC LIMIT 1
+  `;
+  const queryArray = [cashToCreator, cashToCreator, creatorIdStr];
+
+  return { query, queryArray };
+};
+
+const insertCampaignLog = ({
+  campaignId, creatorId, cashToCreator, salesIncomeToMarketer
+}) => {
+  const query = `
+    INSERT INTO campaignLog
+    (campaignId, creatorId, type, cashToCreator, salesIncomeToMarketer)
+    VALUES (?, ?, ?, ?, ?)
+  `;
+  const queryArray = [campaignId, creatorId || '', 'CPS', cashToCreator, salesIncomeToMarketer];
+  return { query, queryArray };
+};
+
+const updateCalcDoneFlag = ({ orderId }) => {
+  const query = 'UPDATE merchandiseOrders SET calculateDoneFlag = ? WHERE id = ?';
+  const queryArray = [1, orderId];
+  return { query, queryArray };
+};
+
+const calculate = async ({
+  orderId, campaignId, merchandiseId, orderPrice, calculateDoneFlag,
+  marketerId, name, targetCreatorId, statusString, deliveryFee,
+  creatorCommission, onadCommission
+}) => {
+  const connection = await pool.promise().getConnection();
+
+  // 수수료 및 광고 대금 추산
+  const { cashToCreator, salesIncomeToMarketer } = getCashesCalculated({
+    orderPrice, creatorCommission, onadCommission
+  });
+
+  connection.beginTransaction();
+  try {
+    // * 1. 광고주 판매대금 처리 (marketerSalesIncome)
+    const marketerSalesIncome = calculateMarketerSalesIncome({
+      marketerId, salesIncomeToMarketer, deliveryFee
+    });
+    await connection.query(marketerSalesIncome.query, marketerSalesIncome.queryArray);
+
+    // * 2. 방송인 수익금 처리 (creatorIncome)
+    const creatorIncome = calculateCreatorIncome({
+      creatorId: targetCreatorId, cashToCreator
+    });
+    await connection.query(creatorIncome.query, creatorIncome.queryArray);
+
+    // * 3. 캠페인 계산 로그 처리 (campaignLog)
+    const campaignLog = insertCampaignLog({
+      campaignId, creatorId: targetCreatorId, cashToCreator, salesIncomeToMarketer
+    });
+    await connection.query(campaignLog.query, campaignLog.queryArray);
+
+    // * 4. 모두 완료 후, 주문의 계산완료플래그를 true로 처리 (merchandiseOrders - calculateDoneFlag)
+    const doneFlag = updateCalcDoneFlag({ orderId });
+    await connection.query(doneFlag.query, doneFlag.queryArray);
+
+    connection.commit();
+    console.log(`[${new Date().toLocaleString()}] ${campaignId} 캠페인 (상품: ${name}, 방송인: ${targetCreatorId}) 계산 완료`);
+  } catch (e) {
+    console.log(`[order${orderId}, marketer${marketerId}]error occurred during calculate - `, e);
+    connection.rollback();
+  } finally {
+    connection.release();
+  }
+};
+
+async function liveCommerceCalc() {
+  console.info('[liveCommerce] 판매 대금 계산을 시작합니다.');
+
+  const targets = await getTargets().catch((err) => console.error(`[liveCommerce] 계산 대상 목록 가져오는 도중 오류 - ${err}`));
+  console.info('[liveCommerce] 판매 대금 계산 타겟 수: ', targets.length);
+
+  return Promise.all(
+    targets.map((target) => calculate({
+      orderId: target.id,
+      campaignId: target.campaignId,
+      merchandiseId: target.merchandiseId,
+      orderPrice: target.orderPrice,
+      deliveryFee: target.deliveryFee,
+      calculateDoneFlag: target.calculateDoneFlag,
+      marketerId: target.marketerId,
+      name: target.name,
+      targetCreatorId: target.targetCreatorId,
+      statusString: target.statusString,
+      creatorCommission: target.creatorCommission,
+      onadCommission: target.onadCommission,
+    }))
+  )
+    .then(() => console.log(`[${new Date().toLocaleString()}] liveCommerce 판매 대금 계산을 모두 완료하였습니다.`))
+    .catch((err) => {
+      console.error(`[${new Date().toLocaleString()}] liveCommerce 판매 대금 계산 중 오류 발생`);
+      console.error(err);
+      return 0;
+    });
+}
+
+module.exports = liveCommerceCalc;

--- a/calculator/model/connectionPool.js
+++ b/calculator/model/connectionPool.js
@@ -1,4 +1,4 @@
-const mysql = require('mysql');
+const mysql = require('mysql2');
 
 const pool = mysql.createPool({
   host: process.env.DB_HOST,

--- a/calculator/package.json
+++ b/calculator/package.json
@@ -8,6 +8,6 @@
   "dependencies": {
     "axios": "^0.19.1",
     "dotenv": "^8.2.0",
-    "mysql": "^2.17.1"
+    "mysql2": "^2.2.5"
   }
 }

--- a/calculator/package.json
+++ b/calculator/package.json
@@ -3,11 +3,15 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "start": "node app.js"
+    "start": "node app.js",
+    "test": "jest"
   },
   "dependencies": {
     "axios": "^0.19.1",
     "dotenv": "^8.2.0",
     "mysql2": "^2.2.5"
+  },
+  "devDependencies": {
+    "jest": "^26.6.3"
   }
 }

--- a/calculator/utils/cps/commission.js
+++ b/calculator/utils/cps/commission.js
@@ -1,0 +1,39 @@
+const getCashesCalculatedForLiveCommerce = ({ orderPrice, creatorCommission, onadCommission }) => {
+  const cashToCreator = Math.round(orderPrice * creatorCommission);
+  const cashToOnad = Math.round(orderPrice * onadCommission);
+  const salesIncomeToMarketer = orderPrice - cashToCreator - cashToOnad;
+  return { cashToCreator, salesIncomeToMarketer };
+};
+
+
+/**
+   * 각 유저별 계산 대금을 구합니다. 리뷰/자랑하기/응원하기 글의 대상인 방송인이 있는 지 여부를 기준으로
+   * 계산 대금은 다르게 계산됩니다.
+   * @author hwasurr
+   * @param { number } orderPrice 계산이 필요한 판매 대금
+   * @param { boolean } isCreatorExists 리뷰/자랑하기/응원하기 글의 대상인 방송인이 있는지 여부
+   * 1. 방송인 A로부터 유입된 시청자가 구입 + 인증(리뷰or자랑하기)**글을 남기고** 구매완료 시
+   *    - **⇒ 광고주 70 %, 방송인 A 20 %, 온애드 10 %**
+   * 
+   * 2. 방송인 A로부터 유입된 시청자가 구입 + 인증(리뷰or자랑하기)**글을 남기지 않고** 구매완료 시
+   *    - **⇒ 광고주 90 %, 온애드 10 %**
+   */
+const getCashesCalculated = ({
+  totalOrderPrice, isCreatorExists, creatorCommission, onadCommission
+}) => {
+  if (isCreatorExists) { // 1 번의 경우
+    const cashToCreator = Math.round(totalOrderPrice * creatorCommission);
+    const cashToOnad = Math.round(totalOrderPrice * onadCommission);
+    const salesIncomeToMarketer = totalOrderPrice - cashToCreator - cashToOnad;
+    return { cashToCreator, salesIncomeToMarketer };
+  }
+  const cashToCreator = 0;
+  const cashToOnad = Math.round(totalOrderPrice * onadCommission);
+  const salesIncomeToMarketer = totalOrderPrice - cashToOnad;
+  return { cashToCreator, salesIncomeToMarketer };
+};
+
+module.exports = {
+  getCashesCalculatedForLiveCommerce,
+  getCashesCalculated,
+};

--- a/calculator/utils/cps/queries.js
+++ b/calculator/utils/cps/queries.js
@@ -4,7 +4,7 @@
  * @param {object} param0 orderId
  * @returns null | affectedRows
  */
-export const getUpdateFlag = ({ orderId }) => {
+const getUpdateFlag = ({ orderId }) => {
   const query = 'UPDATE merchandiseOrders SET calculateDoneFlag = ? WHERE id = ?';
   const queryArray = [1, orderId];
   return { query, queryArray };
@@ -15,7 +15,7 @@ export const getUpdateFlag = ({ orderId }) => {
 * 계산 로그를 campaignLog에 적재
 * @param {object} param0 campaignId, creatorId, cashToCreator, salesIncomeToMarketer
 */
-export const getInsertCampaignLog = ({
+const getInsertCampaignLog = ({
   campaignId, creatorId, cashToCreator, salesIncomeToMarketer
 }) => {
   const query = `
@@ -34,7 +34,7 @@ export const getInsertCampaignLog = ({
  * @author hwasaurr
  * @param {object} param0 creatorId, cashToCreator
  */
-export const getCalculateCreatorIncome = ({ creatorId, cashToCreator }) => {
+const getCalculateCreatorIncome = ({ creatorId, cashToCreator }) => {
   if (creatorId && cashToCreator) {
     const creatorIdStr = String(creatorId);
     const query = `
@@ -57,7 +57,7 @@ export const getCalculateCreatorIncome = ({ creatorId, cashToCreator }) => {
  * @author hwasurr
  * @param {object} param0 marketerId, salesIncomeToMarketer
  */
-export const getCalculateMarketerSalesIncome = ({
+const getCalculateMarketerSalesIncome = ({
   marketerId, salesIncomeToMarketer, deliveryFee
 }) => {
   const query = `
@@ -73,4 +73,12 @@ export const getCalculateMarketerSalesIncome = ({
     salesIncomeToMarketer, salesIncomeToMarketer, deliveryFee, deliveryFee, marketerId,
   ];
   return { query, queryArray };
+};
+
+
+module.exports = {
+  getUpdateFlag,
+  getInsertCampaignLog,
+  getCalculateCreatorIncome,
+  getCalculateMarketerSalesIncome,
 };

--- a/calculator/utils/cps/queries.js
+++ b/calculator/utils/cps/queries.js
@@ -1,0 +1,76 @@
+
+/**
+ * 해당 주문의 계산완료 여부를 "완료" 로 변경합니다.
+ * @param {object} param0 orderId
+ * @returns null | affectedRows
+ */
+export const getUpdateFlag = ({ orderId }) => {
+  const query = 'UPDATE merchandiseOrders SET calculateDoneFlag = ? WHERE id = ?';
+  const queryArray = [1, orderId];
+  return { query, queryArray };
+};
+
+
+/**
+* 계산 로그를 campaignLog에 적재
+* @param {object} param0 campaignId, creatorId, cashToCreator, salesIncomeToMarketer
+*/
+export const getInsertCampaignLog = ({
+  campaignId, creatorId, cashToCreator, salesIncomeToMarketer
+}) => {
+  const query = `
+   INSERT INTO campaignLog
+   (campaignId, creatorId, type, cashToCreator, salesIncomeToMarketer)
+   VALUES (?, ?, ?, ?, ?)
+ `;
+  const queryArray = [campaignId, creatorId || '', 'CPS', cashToCreator, salesIncomeToMarketer];
+  return { query, queryArray };
+};
+
+
+/**
+ * 방송인 수익금을 입력합니다. 주문의 리뷰/자랑하기/응원하기 글의 대상으로 크리에이터가 있는 경우에만 실행되어야 합니다.
+ * (merchandiseOrderComments 에 있는 지 여부에 따라 진행 여부가 판단됨)
+ * @author hwasaurr
+ * @param {object} param0 creatorId, cashToCreator
+ */
+export const getCalculateCreatorIncome = ({ creatorId, cashToCreator }) => {
+  if (creatorId && cashToCreator) {
+    const creatorIdStr = String(creatorId);
+    const query = `
+    INSERT INTO creatorIncome (creatorId, creatorTotalIncome, creatorReceivable)
+    SELECT
+      creatorId,
+      IFNULL(MAX(creatorTotalIncome), 0) + ? AS creatorTotalIncome,
+      IFNULL(MAX(creatorReceivable), 0) + ? AS creatorReceivable
+    FROM creatorIncome AS a WHERE creatorId = ? ORDER BY date DESC LIMIT 1
+    `;
+    const queryArray = [cashToCreator, cashToCreator, creatorIdStr];
+    return { query, queryArray };
+  }
+  return null;
+};
+
+
+/**
+ * 광고주 판매대금을 입력합니다.
+ * @author hwasurr
+ * @param {object} param0 marketerId, salesIncomeToMarketer
+ */
+export const getCalculateMarketerSalesIncome = ({
+  marketerId, salesIncomeToMarketer, deliveryFee
+}) => {
+  const query = `
+  INSERT INTO marketerSalesIncome (marketerId, totalIncome, receivable, totalDeliveryFee, receivableDeliveryFee) 
+  SELECT
+    marketerId,
+    IFNULL(MAX(totalIncome), 0) + ? AS totalIncome,
+    IFNULL(MAX(receivable), 0) + ? AS receivable,
+    IFNULL(MAX(totalDeliveryFee), 0) + ? AS totalDeliveryFee,
+    IFNULL(MAX(receivableDeliveryFee), 0) + ? AS receivableDeliveryFee
+  FROM marketerSalesIncome AS a WHERE marketerId = ? ORDER BY createDate DESC LIMIT 1`;
+  const queryArray = [
+    salesIncomeToMarketer, salesIncomeToMarketer, deliveryFee, deliveryFee, marketerId,
+  ];
+  return { query, queryArray };
+};

--- a/calculator/utils/cps/queries.js
+++ b/calculator/utils/cps/queries.js
@@ -19,10 +19,10 @@ const getInsertCampaignLog = ({
   campaignId, creatorId, cashToCreator, salesIncomeToMarketer
 }) => {
   const query = `
-   INSERT INTO campaignLog
-   (campaignId, creatorId, type, cashToCreator, salesIncomeToMarketer)
-   VALUES (?, ?, ?, ?, ?)
- `;
+    INSERT INTO campaignLog
+    (campaignId, creatorId, type, cashToCreator, salesIncomeToMarketer)
+    VALUES (?, ?, ?, ?, ?)
+  `;
   const queryArray = [campaignId, creatorId || '', 'CPS', cashToCreator, salesIncomeToMarketer];
   return { query, queryArray };
 };
@@ -61,14 +61,14 @@ const getCalculateMarketerSalesIncome = ({
   marketerId, salesIncomeToMarketer, deliveryFee
 }) => {
   const query = `
-  INSERT INTO marketerSalesIncome (marketerId, totalIncome, receivable, totalDeliveryFee, receivableDeliveryFee) 
-  SELECT
-    marketerId,
-    IFNULL(MAX(totalIncome), 0) + ? AS totalIncome,
-    IFNULL(MAX(receivable), 0) + ? AS receivable,
-    IFNULL(MAX(totalDeliveryFee), 0) + ? AS totalDeliveryFee,
-    IFNULL(MAX(receivableDeliveryFee), 0) + ? AS receivableDeliveryFee
-  FROM marketerSalesIncome AS a WHERE marketerId = ? ORDER BY createDate DESC LIMIT 1`;
+    INSERT INTO marketerSalesIncome (marketerId, totalIncome, receivable, totalDeliveryFee, receivableDeliveryFee) 
+    SELECT
+      marketerId,
+      IFNULL(MAX(totalIncome), 0) + ? AS totalIncome,
+      IFNULL(MAX(receivable), 0) + ? AS receivable,
+      IFNULL(MAX(totalDeliveryFee), 0) + ? AS totalDeliveryFee,
+      IFNULL(MAX(receivableDeliveryFee), 0) + ? AS receivableDeliveryFee
+    FROM marketerSalesIncome AS a WHERE marketerId = ? ORDER BY createDate DESC LIMIT 1`;
   const queryArray = [
     salesIncomeToMarketer, salesIncomeToMarketer, deliveryFee, deliveryFee, marketerId,
   ];


### PR DESCRIPTION
## 라이브러리 업그레이드

mysql -> mysql2
프로미스 관련 기능 사용을 위해 mysql2 로 변경, doQuery는 mysql2에서도 동일하게 작동.

## 데이터 처리

1. 상품은 라이브커머스용 상품인지 아닌지 구분이 필요하다.
    - [x]  데이터 컬럼 생성
    - `merchandiseRegistered.isLiveCommerce` 0 = 라이브커머스 아님, 1 = 라이브커머스 맞음
2. 모든 상품은 방송인수수료 비율, 온애드 수수료 비율을 가진다.
    - [x]  데이터 컬럼 생성
    - `merchandiseRegistered.creatorCommission` ⇒ 방송인 수수료 비율
    - `merchandiseRegistered.onadCommission` ⇒ 온애드 수수료 비율

## 로직 처리

1. 라이브커머스계산
    - [x]  기존 CPS와 달리, 방송인에게 보내는 응원메시지가 없는 경우에도 수익금을 부여한다.
    - [x]  상품의 수수료 비율에 따라 금액을 계산
2. CPS 계산
    - [x]  상품의 수수료 비율에 따라 금액을 계산