### PR TITLE
Update: 개인알림 읽음처리시 목록 새로고침 현상 제거

### DIFF
--- a/client-ts/src/organisms/mypage/layouts/Navbars/sub/NotificationPopper.tsx
+++ b/client-ts/src/organisms/mypage/layouts/Navbars/sub/NotificationPopper.tsx
@@ -38,15 +38,12 @@ export default function NotificationPopover({
 }: {
   anchorEl: HTMLElement;
   notificationData: Notification[];
-  successCallback: () => void;
+  successCallback: (targetIdx: number) => void;
   handleAnchorClose: () => void;
 }): JSX.Element {
   const userType = window.location.pathname.split('/')[2];
   const classes = useStyles();
-  const notiReadPatch = usePatchRequest(`/${userType}/notification`, () => {
-    // 클라이언트 알림 읽음 처리
-    successCallback(); // 개인 알림 데이터 리로드
-  });
+  const notiReadPatch = usePatchRequest(`/${userType}/notification`);
   return (
     <Popover
       open={Boolean(anchorEl)}
@@ -78,9 +75,13 @@ export default function NotificationPopover({
           {notificationData.map(noti => (
             <div key={noti.index}>
               <MenuItem
-                onClick={(): void => {
+                onClick={async (): Promise<void> => {
                   if (noti.readState === UNREAD_STATE) {
-                    notiReadPatch.doPatchRequest({ index: noti.index });
+                    // 알림 읽음 처리
+                    notiReadPatch
+                      .doPatchRequest({ index: noti.index })
+                      // 개인 알림 데이터 리로드
+                      .then(() => successCallback(noti.index));
                   }
                 }}
               >


### PR DESCRIPTION
# 기술부채항목

- pub/sub 이 없어 실시간 알림이 불가능하다. → 4
- 읽기 처리시, 모든 데이터를 다시 불러오므로 알림창이 깜빡임. → 2

    알림 데이터가 많이 쌓인 경우, 읽기 처리하는 데에 시간도 오래걸리며 서버 자원도 많이 쓰임.

# 할 일

- [x]  알림 읽음 처리 이후 알림목록 새롭게 불러오는 방식 제거
- [x]  알림 읽음 처리 요청이후 요청완료시 알림 불러온 데이터 조작하여 컴포넌트 렌더링만 변경하도록 수정
- pub/sub 적용은 하지 않는다. 적용으로 오는 이점보다 적용의 난이도가 높다.