### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/push-afreeca-link-note-ecs.yml
+++ b/.github/workflows/push-afreeca-link-note-ecs.yml
@@ -23,7 +23,7 @@ jobs:
           aws-region: ap-northeast-2
 
       - name: Build, tag, and push image to Docker Hub
-        uses: elgohr/Publish-Docker-Github-Action@2.14
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           workdir: afreeca-link-note-crawl
           name: ${{ secrets.DOCKER_USERNAME }}/afreeca-link-note-crawl

--- a/.github/workflows/push-api-ecs.yml
+++ b/.github/workflows/push-api-ecs.yml
@@ -30,7 +30,7 @@ jobs:
           cd -
 
       - name: Build, tag, and push image to Docker Hub
-        uses: elgohr/Publish-Docker-Github-Action@2.14
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           workdir: api
           name: ${{ secrets.DOCKER_USERNAME }}/onad_web_api

--- a/.github/workflows/push-calculator-ecs.yml
+++ b/.github/workflows/push-calculator-ecs.yml
@@ -23,7 +23,7 @@ jobs:
           aws-region: ap-northeast-2
 
       - name: Build, tag, and push image to Docker Hub
-        uses: elgohr/Publish-Docker-Github-Action@2.14
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           workdir: calculator
           name: ${{ secrets.DOCKER_USERNAME }}/calculator

--- a/.github/workflows/push-chatbot-twitch-ecs.yml
+++ b/.github/workflows/push-chatbot-twitch-ecs.yml
@@ -30,7 +30,7 @@ jobs:
           cd -
 
       - name: Build, tag, and push image to Docker Hub
-        uses: elgohr/Publish-Docker-Github-Action@2.14
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           workdir: chatbot-twitch
           name: ${{ secrets.DOCKER_USERNAME }}/onad_twitch_bot

--- a/.github/workflows/push-live-commerce-ecs.yml
+++ b/.github/workflows/push-live-commerce-ecs.yml
@@ -30,7 +30,7 @@ jobs:
           cd -
 
       - name: Build, tag, and push image to Docker Hub
-        uses: elgohr/Publish-Docker-Github-Action@2.14
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           workdir: live-commerce
           name: ${{ secrets.DOCKER_USERNAME }}/onad_live-commerce

--- a/.github/workflows/push-socket-ecs.yml
+++ b/.github/workflows/push-socket-ecs.yml
@@ -30,7 +30,7 @@ jobs:
           cd -
 
       - name: Build, tag, and push image to Docker Hub
-        uses: elgohr/Publish-Docker-Github-Action@2.14
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           workdir: socket
           name: ${{ secrets.DOCKER_USERNAME }}/onad_socket

--- a/.github/workflows/push-tracker-ecs.yml
+++ b/.github/workflows/push-tracker-ecs.yml
@@ -30,7 +30,7 @@ jobs:
           cd -
 
       - name: Build, tag, and push image to Docker Hub
-        uses: elgohr/Publish-Docker-Github-Action@2.14
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           workdir: tracker
           name: ${{ secrets.DOCKER_USERNAME }}/onad_tracker

--- a/.github/workflows/test-push-api-ecs.yml
+++ b/.github/workflows/test-push-api-ecs.yml
@@ -30,7 +30,7 @@ jobs:
           cd -
 
       - name: Build, tag, and push image to Docker Hub
-        uses: elgohr/Publish-Docker-Github-Action@2.14
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           workdir: api
           name: ${{ secrets.DOCKER_USERNAME }}/onad_web_api

--- a/.github/workflows/test-push-socket-ecs.yml
+++ b/.github/workflows/test-push-socket-ecs.yml
@@ -30,7 +30,7 @@ jobs:
           cd -
 
       - name: Build, tag, and push image to Docker Hub
-        uses: elgohr/Publish-Docker-Github-Action@2.14
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           workdir: socket
           name: ${{ secrets.DOCKER_USERNAME }}/onad_socket

--- a/.github/workflows/test-push-tracker-ecs.yml
+++ b/.github/workflows/test-push-tracker-ecs.yml
@@ -30,7 +30,7 @@ jobs:
           cd -
 
       - name: Build, tag, and push image to Docker Hub
-        uses: elgohr/Publish-Docker-Github-Action@2.14
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           workdir: tracker
           name: ${{ secrets.DOCKER_USERNAME }}/onad_tracker


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore